### PR TITLE
refactor: SaveErpEntityRequest 내부에 SolutionEffectEntityRequest 중첩 정의

### DIFF
--- a/src/main/java/startwithco/startwithbackend/solution/erp/controller/request/ErpRequest.java
+++ b/src/main/java/startwithco/startwithbackend/solution/erp/controller/request/ErpRequest.java
@@ -1,6 +1,5 @@
 package startwithco.startwithbackend.solution.erp.controller.request;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
 import startwithco.startwithbackend.exception.badRequest.BadRequestErrorResult;
@@ -13,7 +12,6 @@ import java.util.List;
 
 import static io.micrometer.common.util.StringUtils.isBlank;
 
-@Slf4j
 public class ErpRequest {
     public record SaveErpEntityRequest(
             Long vendorSeq,
@@ -48,13 +46,13 @@ public class ErpRequest {
                 throw new BadRequestException(BadRequestErrorResult.BAD_REQUEST_EXCEPTION);
             }
         }
-    }
 
-    public record SolutionEffectEntityRequest(
-            String effectName,
-            Long percent,
-            DIRECTION direction
-    ) {
+        public record SolutionEffectEntityRequest(
+                String effectName,
+                Long percent,
+                DIRECTION direction
+        ) {
 
+        }
     }
 }


### PR DESCRIPTION
- SolutionEffectEntityRequest를 SaveErpEntityRequest 내부 record로 이동
- 관련 요청 스코프를 명확히 하고 클래스 구조 간결화
- 외부 접근 시 SaveErpEntityRequest.SolutionEffectEntityRequest 형태로 일관성 유지

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-