### PR TITLE
feat: 토스페이먼츠 결제 승인 응답 WebClient 처리 및 카드/가상계좌 분기 응답 구현

### DIFF
--- a/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
+++ b/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
@@ -37,6 +37,8 @@ public class ExceptionCodeMapper {
         SERVER_MAP.put("결제 응답 파싱 중 오류가 발생했습니다.", "SERVER_EXCEPTION_003");
         SERVER_MAP.put("구매 확정, 정산 완료 결제 요청이지만 결제 승인된 정보가 없습니다.", "SERVER_EXCEPTION_004");
         SERVER_MAP.put("중복된 결제 데이터가 존재합니다.", "SERVER_EXCEPTION_005");
+        SERVER_MAP.put("토스페이먼츠 결제 승인 실패", "SERVER_EXCEPTION_006");
+        SERVER_MAP.put("WebClient 응답 에러가 발생했습니다.", "SERVER_EXCEPTION_007");
 
         // UnauthorizedException
     }

--- a/src/main/java/startwithco/startwithbackend/payment/payment/controller/PaymentController.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/controller/PaymentController.java
@@ -18,7 +18,6 @@ import startwithco.startwithbackend.exception.handler.GlobalExceptionHandler;
 import startwithco.startwithbackend.payment.payment.service.PaymentService;
 
 import static startwithco.startwithbackend.payment.payment.controller.request.PaymentRequest.*;
-import static startwithco.startwithbackend.payment.payment.controller.response.PaymentResponse.*;
 
 @RestController
 @RequestMapping("/api/b2b-service/payment")
@@ -29,17 +28,20 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PostMapping(
-            name = "토스페이먼츠 PG사 연동 결제하기"
+            name = "토스페이먼츠 PG사 연동 결제하기 (가상계좌, 카드 결제)"
     )
     @Operation(
-            summary = "토스페이먼츠 PG사 연동 결제하기 API",
+            summary = "토스페이먼츠 PG사 결제 승인 API (가상계좌, 카드 결제)",
             description = """
                     1. 광클 방지를 위한 disable 처리해주세요.\n
                     2. amount의 경우 부가세 포함한 가격을 보내야합니다.\n
                     3. 만약 결제 요청의 상태가 REQUEST가 아닐 경우 결제가 진행되지 않습니다.\n
-                    4. paymentKey의 경우 SuccessURL에서 받은 값, orderId의 경우 UUID 생성해서 넘겨주시면 됩니다.\n
+                    4. paymentKey의 경우 SuccessURL에서 받은 값, orderId의 경우 결제 요청 조회에서 오는 orderId 값을 넘겨주시면 됩니다.\n
                     5. SERVER - TOSS 사이 간 orderId로 멱등성 처리가 돼 있습니다.\n
-                    6. 만약 결제 승인 오류가 나게 되면 해당 결제의 PaymentEvent에 orderId가 새롭게 발급됩니다. 다시 결제하고자 한다면 결제 요청 조회 후 새로운 orderId로 결제 승인 해야합니다.
+                    6. 만약 결제 승인 오류가 나게 되면 중복 결제 방지를 위해 해당 결제의 PaymentEvent에 orderId가 새롭게 발급됩니다. 다시 결제하고자 한다면 결제 요청 조회 후 새로운 orderId로 결제 승인 해야합니다.\n
+                    7. 카드 결제, 가상 계좌 결제 승인 모두 이 API를 사용하지만 Response의 method("카드", "가상계좌")에 따라 반환값이 다릅니다.\n
+                    8. 가상계좌 개발자 센터: https://docs.tosspayments.com/guides/v2/payment-window/integration-virtual-account\n
+                    9. 카드 결제 개발자 센터: https://docs.tosspayments.com/guides/payment/integration\n
                     """
     )
     @ApiResponses(value = {
@@ -52,8 +54,10 @@ public class PaymentController {
             @ApiResponse(responseCode = "BAD_REQUEST_EXCEPTION_004", description = "해당 결제 요청은 승인할 수 없습니다. 유효하지 않은 주문이거나 이미 처리된 결제입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "SERVER_EXCEPTION_005", description = "중복된 결제 데이터가 존재합니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "SERVER_EXCEPTION_003", description = "결제 응답 파싱 중 오류가 발생했습니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "SERVER_EXCEPTION_006", description = "토스페이먼츠 결제 승인 실패", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "SERVER_EXCEPTION_007", description = "WebClient 응답 에러가 발생했습니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
     })
-    public Mono<ResponseEntity<BaseResponse<TossPaymentApprovalResponse>>> tossPaymentApproval(
+    public Mono<ResponseEntity<BaseResponse<?>>> tossPaymentApproval(
             @Valid
             @RequestBody TossPaymentApprovalRequest request
     ) {

--- a/src/main/java/startwithco/startwithbackend/payment/payment/controller/response/PaymentResponse.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/controller/response/PaymentResponse.java
@@ -3,13 +3,32 @@ package startwithco.startwithbackend.payment.payment.controller.response;
 import java.time.LocalDateTime;
 
 public class PaymentResponse {
-    public record TossPaymentApprovalResponse(
+    public record TossCardPaymentApprovalResponse(
             String orderId,
             String orderName,
             String paymentKey,
             String method,
             Integer totalAmount,
             LocalDateTime approvedAt,
+            String cardCompany,
+            String cardNumber,
+            String cardType,
+            String receiptUrl
+    ) {}
+
+    public record TossVirtualAccountPaymentResponse(
+            String orderId,
+            String orderName,
+            String paymentKey,
+            String method,
+            Integer totalAmount,
+            LocalDateTime requestedAt,
+            String virtualAccountNumber,
+            String bankCode,
+            String customerName,
+            LocalDateTime dueDate,
+            String cashReceiptUrl,
+            String secret,
             String receiptUrl
     ) {}
 }

--- a/src/main/java/startwithco/startwithbackend/payment/payment/domain/PaymentEntity.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/domain/PaymentEntity.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Where;
 import startwithco.startwithbackend.base.BaseTimeEntity;
+import startwithco.startwithbackend.payment.payment.util.METHOD;
 import startwithco.startwithbackend.payment.payment.util.PAYMENT_STATUS;
 import startwithco.startwithbackend.payment.paymentEvent.domain.PaymentEventEntity;
 
@@ -41,6 +42,13 @@ public class PaymentEntity extends BaseTimeEntity {
     @Column(name = "payment_status", nullable = false)
     private PAYMENT_STATUS paymentStatus;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "method", nullable = true)
+    private METHOD method;
+
+    @Column(name = "secret", nullable = true)
+    private String secret;
+
     @Column(name = "payment_completed_at", nullable = true)
     private LocalDateTime paymentCompletedAt;
 
@@ -62,5 +70,13 @@ public class PaymentEntity extends BaseTimeEntity {
 
     public void updatePaymentStatus(PAYMENT_STATUS paymentStatus) {
         this.paymentStatus = paymentStatus;
+    }
+
+    public void updateMethod(METHOD method) {
+        this.method = method;
+    }
+
+    public void updateSecret(String secret) {
+        this.secret = secret;
     }
 }

--- a/src/main/java/startwithco/startwithbackend/payment/payment/util/METHOD.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/util/METHOD.java
@@ -1,0 +1,7 @@
+package startwithco.startwithbackend.payment.payment.util;
+
+public enum METHOD {
+    CARD,
+    VIRTUAL_ACCOUNT,
+    ;
+}

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/domain/PaymentEventEntity.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/domain/PaymentEventEntity.java
@@ -43,6 +43,12 @@ public class PaymentEventEntity extends BaseTimeEntity {
     @Column(name = "amount", nullable = false)
     private Long amount;
 
+    @Column(name = "tax", nullable = false)
+    private Long tax;
+
+    @Column(name = "actual_amount", nullable = false)
+    private Long actualAmount;
+
     @Column(name = "contract_confirmation_url", nullable = false)
     private String contractConfirmationUrl;
 

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/service/PaymentEventService.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/service/PaymentEventService.java
@@ -89,6 +89,8 @@ public class PaymentEventService {
         String s3ContractConfirmationUrl = commonService.uploadPDFFile(contractConfirmationUrl);
         String s3RefundPolicyUrl = commonService.uploadPDFFile(refundPolicyUrl);
         String orderId = UUID.randomUUID().toString();
+        Long tax = (long) (request.amount() * 0.1);
+        Long actualAmount = request.amount() + tax;
 
         PaymentEventEntity paymentEventEntity = PaymentEventEntity.builder()
                 .vendorEntity(vendorEntity)
@@ -96,6 +98,8 @@ public class PaymentEventService {
                 .solutionEntity(solutionEntity)
                 .paymentEventName(request.paymentEventName())
                 .amount(request.amount())
+                .tax(tax)
+                .actualAmount(actualAmount)
                 .contractConfirmationUrl(s3ContractConfirmationUrl)
                 .refundPolicyUrl(s3RefundPolicyUrl)
                 .paymentEventStatus(PAYMENT_EVENT_STATUS.REQUESTED)
@@ -203,10 +207,6 @@ public class PaymentEventService {
         VendorEntity vendorEntity = solutionEntity.getVendorEntity();
         ConsumerEntity consumerEntity = paymentEventEntity.getConsumerEntity();
 
-        Long amount = paymentEventEntity.getAmount();
-        Long tax = (long) (amount * 0.1);
-        Long actualAmount = amount + tax;
-
         return new GetPaymentEventEntityOrderResponse(
                 paymentEventEntity.getPaymentEventSeq(),
                 paymentEventEntity.getOrderId(),
@@ -215,9 +215,9 @@ public class PaymentEventService {
                 vendorEntity.getVendorName(),
                 vendorEntity.getVendorBannerImageUrl(),
                 solutionEntity.getRepresentImageUrl(),
-                amount,
-                tax,
-                actualAmount,
+                paymentEventEntity.getAmount(),
+                paymentEventEntity.getTax(),
+                paymentEventEntity.getActualAmount(),
                 consumerEntity.getConsumerSeq(),
                 consumerEntity.getConsumerName(),
                 consumerEntity.getPhoneNumber(),

--- a/src/main/resources/static/nocard.html
+++ b/src/main/resources/static/nocard.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>가상계좌 결제 테스트</title>
+    <script src="https://js.tosspayments.com/v1/payment"></script>
+</head>
+<body>
+<h2>PG사 결제 테스트 (가상계좌)</h2>
+<button id="pay">무통장입금(가상계좌) 결제하기</button>
+
+<script>
+    const clientKey = "test_ck_D5GePWvyJnrK0W0k6q8gLzN97Eoq";
+    const tossPayments = TossPayments(clientKey);
+
+    document.getElementById("pay").addEventListener("click", async () => {
+        const orderId = crypto.randomUUID();
+        const amount = 10000;
+
+        tossPayments.requestPayment("가상계좌", {
+            amount,
+            orderId,
+            orderName: "무통장입금 테스트 주문",
+            customerName: "김토스",
+            customerEmail: "customer@example.com",
+            customerMobilePhone: "01046174261", // 계좌 안내 받을 번호
+            successUrl: window.location.origin + "/success.html",
+            failUrl: window.location.origin + "/fail.html",
+            virtualAccount: {
+                useEscrow: false,
+                validHours: 24,
+                cashReceipt: {
+                    type: "소득공제"
+                }
+            }
+        }).catch(e => alert("결제 실패: " + e.message));
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- WebClient로 토스페이먼츠 결제 승인 API 호출 시 JsonNode 응답 처리 방식 개선
- 결제 수단(method)에 따라 카드 결제와 가상계좌 결제 응답을 구분하여 각각 Response 객체 반환
  - TossCardPaymentApprovalResponse: 카드사, 카드번호, 승인일시 등 포함
  - TossVirtualAccountPaymentResponse: 계좌번호, 은행 코드, 입금기한 등 포함
- 가상계좌 결제 시 secret 저장 로직 추가
- 결제 승인 실패 시 payment 상태 복구 및 orderId 재생성 처리

## 📝 참고사항
- 

## 📚 기타
-