### PR TITLE
docs: 토스페이먼츠 결제 승인 API 응답 명세 개선

### DIFF
--- a/src/main/java/startwithco/startwithbackend/payment/payment/controller/PaymentController.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/controller/PaymentController.java
@@ -15,9 +15,11 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 import startwithco.startwithbackend.base.BaseResponse;
 import startwithco.startwithbackend.exception.handler.GlobalExceptionHandler;
+import startwithco.startwithbackend.payment.payment.controller.response.PaymentResponse;
 import startwithco.startwithbackend.payment.payment.service.PaymentService;
 
 import static startwithco.startwithbackend.payment.payment.controller.request.PaymentRequest.*;
+import static startwithco.startwithbackend.payment.payment.controller.response.PaymentResponse.*;
 
 @RestController
 @RequestMapping("/api/b2b-service/payment")
@@ -45,7 +47,7 @@ public class PaymentController {
                     """
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "SUCCESS", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(oneOf = {TossCardPaymentApprovalResponse.class, TossVirtualAccountPaymentResponse.class}))),
             @ApiResponse(responseCode = "SERVER_EXCEPTION_001", description = "내부 서버 오류가 발생했습니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "BAD_REQUEST_EXCEPTION_001", description = "요청 데이터 오류입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "NOT_FOUND_EXCEPTION_002", description = "존재하지 않는 결제 요청입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 카드/가상계좌 결제 승인 API 응답 타입에 대한 다형성 명세 추가
  - method 값에 따라 TossCardPaymentApprovalResponse 또는 TossVirtualAccountPaymentResponse 응답
  - @ApiResponse에 oneOf 명시하여 Swagger 문서에서 명확히 구분되도록 개선
- @Operation(description)에 각 결제 방식별 응답 구조 차이에 대한 설명 보완

## 📝 참고사항
- 

## 📚 기타
-