### PR TITLE
feat: 벤더/수요기업 대시보드 조회 API 구현

### DIFF
--- a/src/main/java/startwithco/startwithbackend/b2b/consumer/controller/response/ConsumerResponse.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/consumer/controller/response/ConsumerResponse.java
@@ -2,13 +2,18 @@ package startwithco.startwithbackend.b2b.consumer.controller.response;
 
 import lombok.Builder;
 import startwithco.startwithbackend.b2b.consumer.domain.ConsumerEntity;
+import startwithco.startwithbackend.payment.payment.util.METHOD;
+import startwithco.startwithbackend.payment.payment.util.PAYMENT_STATUS;
+
+import java.time.LocalDateTime;
 
 public class ConsumerResponse {
     public record LoginConsumerResponse(
             String accessToken,
             String refreshToken,
             Long consumerSeq
-    ) {}
+    ) {
+    }
 
     @Builder
     public record GetConsumerInfo(
@@ -29,5 +34,20 @@ public class ConsumerResponse {
                     .consumerImageUrl(consumerEntity.getConsumerImageUrl())
                     .build();
         }
+    }
+
+    public record GetConsumerDashboardResponse(
+            Long consumerSeq,
+            PAYMENT_STATUS paymentStatus,
+            LocalDateTime paymentCompletedAt,
+            String representImageUrl,
+            String vendorName,
+            Long solutionSeq,
+            String solutionName,
+            METHOD method,
+            Long amount,
+            boolean existReview
+    ) {
+
     }
 }

--- a/src/main/java/startwithco/startwithbackend/b2b/vendor/controller/response/VendorResponse.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/vendor/controller/response/VendorResponse.java
@@ -18,7 +18,8 @@ public class VendorResponse {
             String accessToken,
             String refreshToken,
             Long vendorSeq
-    ) {}
+    ) {
+    }
 
     @Builder
     public record GetVendorInfo(
@@ -69,5 +70,14 @@ public class VendorResponse {
                     .clientCount(vendorEntity.getClientCount())
                     .build();
         }
+    }
+
+    public record GetVendorDashboardResponse(
+            Long vendorSeq,
+            Long CONFIRMED,
+            Long DONE,
+            Long SETTLED
+    ) {
+
     }
 }

--- a/src/main/java/startwithco/startwithbackend/b2b/vendor/service/VendorService.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/vendor/service/VendorService.java
@@ -20,6 +20,7 @@ import startwithco.startwithbackend.exception.BadRequestException;
 import startwithco.startwithbackend.exception.ConflictException;
 import startwithco.startwithbackend.exception.NotFoundException;
 import startwithco.startwithbackend.exception.ServerException;
+import startwithco.startwithbackend.payment.payment.repository.PaymentEntityRepository;
 import startwithco.startwithbackend.payment.paymentEvent.repository.PaymentEventEntityRepository;
 import startwithco.startwithbackend.solution.solution.domain.SolutionEntity;
 import startwithco.startwithbackend.solution.solution.repository.SolutionEntityRepository;
@@ -40,6 +41,7 @@ import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.ge
 public class VendorService {
     private final VendorEntityRepository vendorEntityRepository;
     private final SolutionEntityRepository solutionEntityRepository;
+    private final PaymentEntityRepository paymentEntityRepository;
     private final CommonService commonService;
     private final BCryptPasswordEncoder encoder;
     private final RedisTemplate<String, String> redisTemplate;
@@ -233,6 +235,23 @@ public class VendorService {
                 request.clientCount()
         );
 
-         vendorEntityRepository.save(vendorEntity);
+        vendorEntityRepository.save(vendorEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public GetVendorDashboardResponse getVendorDashboard(Long vendorSeq) {
+        VendorEntity vendorEntity = vendorEntityRepository.findByVendorSeq(vendorSeq)
+                .orElseThrow(() -> new NotFoundException(
+                        HttpStatus.NOT_FOUND.value(),
+                        "존재하지 않는 벤더 기업입니다.",
+                        getCode("존재하지 않는 벤더 기업입니다.", ExceptionType.NOT_FOUND)
+                ));
+
+        return new GetVendorDashboardResponse(
+                vendorEntity.getVendorSeq(),
+                paymentEntityRepository.countDONEStatusByVendorSeq(vendorEntity.getVendorSeq()),
+                paymentEntityRepository.countDONEStatusByVendorSeq(vendorEntity.getVendorSeq()),
+                paymentEntityRepository.countSETTLEDStatusByVendorSeq(vendorEntity.getVendorSeq())
+        );
     }
 }

--- a/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityJpaRepository.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityJpaRepository.java
@@ -35,4 +35,20 @@ public interface PaymentEntityJpaRepository extends JpaRepository<PaymentEntity,
             WHERE p.orderId = :orderId
             """)
     Optional<PaymentEntity> findByOrderId(@Param("orderId") String orderId);
+
+    @Query("""
+            SELECT COUNT(p)
+            FROM PaymentEntity p
+            WHERE p.paymentEventEntity.vendorEntity.vendorSeq = :vendorSeq
+              AND p.paymentStatus = 'DONE'
+            """)
+    Long countDONEStatusByVendorSeq(@Param("vendorSeq") Long vendorSeq);
+
+    @Query("""
+            SELECT COUNT(p)
+            FROM PaymentEntity p
+            WHERE p.paymentEventEntity.vendorEntity.vendorSeq = :vendorSeq
+              AND p.paymentStatus = 'SETTLED'
+            """)
+    Long countSETTLEDStatusByVendorSeq(Long vendorSeq);
 }

--- a/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepository.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepository.java
@@ -13,4 +13,10 @@ public interface PaymentEntityRepository {
     Optional<PaymentEntity> findBySecret(String secret);
 
     Optional<PaymentEntity> findByOrderId(String orderId);
+
+    List<PaymentEntity> findAllByConsumerSeqAndPaymentStatus(Long consumerSeq, String paymentStatus, int start, int end);
+
+    Long countDONEStatusByVendorSeq(Long vendorSeq);
+
+    Long countSETTLEDStatusByVendorSeq(Long vendorSeq);
 }

--- a/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepositoryImpl.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepositoryImpl.java
@@ -1,8 +1,13 @@
 package startwithco.startwithbackend.payment.payment.repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import startwithco.startwithbackend.exception.BadRequestException;
 import startwithco.startwithbackend.payment.payment.domain.PaymentEntity;
+import startwithco.startwithbackend.payment.payment.domain.QPaymentEntity;
+import startwithco.startwithbackend.payment.payment.util.PAYMENT_STATUS;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +16,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class PaymentEntityRepositoryImpl implements PaymentEntityRepository {
     private final PaymentEntityJpaRepository repository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public PaymentEntity savePaymentEntity(PaymentEntity paymentEntity) {
@@ -30,5 +36,41 @@ public class PaymentEntityRepositoryImpl implements PaymentEntityRepository {
     @Override
     public Optional<PaymentEntity> findByOrderId(String orderId) {
         return repository.findByOrderId(orderId);
+    }
+
+    @Override
+    public List<PaymentEntity> findAllByConsumerSeqAndPaymentStatus(Long consumerSeq, String paymentStatus, int start, int end) {
+        QPaymentEntity qPaymentEntity = QPaymentEntity.paymentEntity;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(qPaymentEntity.paymentEventEntity.consumerEntity.consumerSeq.eq(consumerSeq));
+
+        if (paymentStatus != null) {
+            PAYMENT_STATUS status = PAYMENT_STATUS.valueOf(paymentStatus);
+            builder.and(qPaymentEntity.paymentStatus.eq(status));
+        } else {
+            builder.and(
+                    qPaymentEntity.paymentStatus.eq(PAYMENT_STATUS.DONE)
+                            .or(qPaymentEntity.paymentStatus.eq(PAYMENT_STATUS.SETTLED))
+            );
+        }
+
+        return queryFactory
+                .selectFrom(qPaymentEntity)
+                .where(builder)
+                .orderBy(qPaymentEntity.paymentCompletedAt.desc())
+                .offset(start)
+                .limit(end - start)
+                .fetch();
+    }
+
+    @Override
+    public Long countDONEStatusByVendorSeq(Long vendorSeq) {
+        return repository.countDONEStatusByVendorSeq(vendorSeq);
+    }
+
+    @Override
+    public Long countSETTLEDStatusByVendorSeq(Long vendorSeq) {
+        return repository.countSETTLEDStatusByVendorSeq(vendorSeq);
     }
 }

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/controller/PaymentEventController.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/controller/PaymentEventController.java
@@ -111,33 +111,6 @@ public class PaymentEventController {
         return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), response));
     }
 
-    @DeleteMapping(
-            name = "결제 요청 취소"
-    )
-    @Operation(
-            summary = "결제 요청 취소 API",
-            description = """
-                    1. 광클 방지를 위한 disable 처리해주세요.
-                    2. 해당 결제 요청이 이미 결제 승인 완료면 결제 요청 취소가 불가능합니다.
-                    """
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "SUCCESS", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "SERVER_EXCEPTION_001", description = "내부 서버 오류가 발생했습니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
-            @ApiResponse(responseCode = "BAD_REQUEST_EXCEPTION_001", description = "요청 데이터 오류입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
-            @ApiResponse(responseCode = "NOT_FOUND_EXCEPTION_002", description = "존재하지 않는 결제 요청입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
-    })
-    public ResponseEntity<BaseResponse<String>> deletePaymentEventEntity(
-            @Valid
-            @RequestBody DeletePaymentEventRequest request
-    ) {
-        request.validate();
-
-        paymentEventService.deletePaymentEventEntity(request);
-
-        return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), "SUCCESS"));
-    }
-
     @GetMapping(
             value = "/order",
             name = "결제하기 후 주문내역"

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/controller/response/PaymentEventResponse.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/controller/response/PaymentEventResponse.java
@@ -18,8 +18,7 @@ public class PaymentEventResponse {
             Long amount,
             String contractConfirmationUrl,
             String refundPolicyUrl,
-            LocalDateTime createdAt,
-            Boolean isCanceled
+            LocalDateTime createdAt
     ) {
 
     }

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/domain/PaymentEventEntity.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/domain/PaymentEventEntity.java
@@ -51,11 +51,4 @@ public class PaymentEventEntity extends BaseTimeEntity {
 
     @Column(name = "refund_policy_url", nullable = false)
     private String refundPolicyUrl;
-
-    @Column(name = "is_canceled", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
-    private Boolean isCanceled = false;
-
-    public void updateIsCanceled(Boolean isCanceled) {
-        this.isCanceled = isCanceled;
-    }
 }

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/repository/PaymentEventEntityJpaRepository.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/repository/PaymentEventEntityJpaRepository.java
@@ -15,7 +15,6 @@ public interface PaymentEventEntityJpaRepository extends JpaRepository<PaymentEv
                 SELECT pe
                 FROM PaymentEventEntity pe
                 WHERE pe.paymentEventSeq = :paymentEventSeq
-                  AND pe.isCanceled = false
             """)
     Optional<PaymentEventEntity> findByPaymentEventSeq(@Param("paymentEventSeq") Long paymentEventSeq);
 

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/service/PaymentEventService.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/service/PaymentEventService.java
@@ -80,7 +80,6 @@ public class PaymentEventService {
                     .actualAmount(actualAmount)
                     .contractConfirmationUrl(s3ContractConfirmationUrl)
                     .refundPolicyUrl(s3RefundPolicyUrl)
-                    .isCanceled(false)
                     .build();
 
             paymentEventEntityRepository.savePaymentEventEntity(paymentEventEntity);
@@ -133,26 +132,12 @@ public class PaymentEventService {
                         event.getAmount(),
                         event.getContractConfirmationUrl(),
                         event.getRefundPolicyUrl(),
-                        event.getCreatedAt(),
-                        event.getIsCanceled()
+                        event.getCreatedAt()
                 ));
             }
         }
 
         return result;
-    }
-
-    @Transactional
-    public void deletePaymentEventEntity(DeletePaymentEventRequest request) {
-        PaymentEventEntity paymentEventEntity = paymentEventEntityRepository.findByPaymentEventSeq(request.paymentEventSeq())
-                .orElseThrow(() -> new NotFoundException(
-                        HttpStatus.NOT_FOUND.value(),
-                        "존재하지 않는 결제 요청입니다.",
-                        getCode("존재하지 않는 결제 요청입니다.", ExceptionType.NOT_FOUND)
-                ));
-
-        paymentEventEntity.updateIsCanceled(true);
-        paymentEventEntityRepository.savePaymentEventEntity(paymentEventEntity);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
@@ -229,7 +229,9 @@ public class SolutionService {
         for (SolutionEntity solutionEntity : solutionEntities) {
             VendorEntity vendorEntity = solutionEntity.getVendorEntity();
             Long countSolutionReview = solutionReviewEntityRepository.countBySolutionSeq(solutionEntity.getSolutionSeq());
-            Double averageStar = solutionReviewEntityRepository.averageBySolutionSeq(solutionEntity.getSolutionSeq());
+            Double averageStar = Optional.ofNullable(
+                    solutionReviewEntityRepository.averageBySolutionSeq(solutionEntity.getSolutionSeq())
+            ).orElse(0.0);
 
             response.add(new GetAllSolutionEntityResponse(
                     solutionEntity.getSolutionSeq(),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 벤더 대시보드 API(getVendorDashboard)
  - 벤더 정보 조회
  - 해당 벤더의 결제 상태(DONE, SETTLED) 건수 반환
- 수요기업 대시보드 API(getConsumerDashboard)
  - 수요기업 정보 검증
  - 결제 상태별 결제 내역 페이징 조회
  - 솔루션 리뷰 작성 여부 포함하여 응답 반환

## 📝 참고사항
- 

## 📚 기타
-