### PR TITLE
fix: 소비자 대시보드 조회 시 N+1 문제 해결

### DIFF
--- a/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepositoryImpl.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepositoryImpl.java
@@ -4,10 +4,13 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import startwithco.startwithbackend.b2b.vendor.domain.QVendorEntity;
 import startwithco.startwithbackend.exception.BadRequestException;
 import startwithco.startwithbackend.payment.payment.domain.PaymentEntity;
 import startwithco.startwithbackend.payment.payment.domain.QPaymentEntity;
 import startwithco.startwithbackend.payment.payment.util.PAYMENT_STATUS;
+import startwithco.startwithbackend.payment.paymentEvent.domain.QPaymentEventEntity;
+import startwithco.startwithbackend.solution.solution.domain.QSolutionEntity;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +44,9 @@ public class PaymentEntityRepositoryImpl implements PaymentEntityRepository {
     @Override
     public List<PaymentEntity> findAllByConsumerSeqAndPaymentStatus(Long consumerSeq, String paymentStatus, int start, int end) {
         QPaymentEntity qPaymentEntity = QPaymentEntity.paymentEntity;
+        QPaymentEventEntity qPaymentEventEntity = QPaymentEventEntity.paymentEventEntity;
+        QSolutionEntity qSolutionEntity = QSolutionEntity.solutionEntity;
+        QVendorEntity qVendorEntity = QVendorEntity.vendorEntity;
 
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(qPaymentEntity.paymentEventEntity.consumerEntity.consumerSeq.eq(consumerSeq));
@@ -57,6 +63,9 @@ public class PaymentEntityRepositoryImpl implements PaymentEntityRepository {
 
         return queryFactory
                 .selectFrom(qPaymentEntity)
+                .join(qPaymentEntity.paymentEventEntity, qPaymentEventEntity).fetchJoin()
+                .join(qPaymentEventEntity.solutionEntity, qSolutionEntity).fetchJoin()
+                .join(qPaymentEventEntity.vendorEntity, qVendorEntity).fetchJoin()
                 .where(builder)
                 .orderBy(qPaymentEntity.paymentCompletedAt.desc())
                 .offset(start)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- PaymentEntity → PaymentEventEntity → Solution/Vendor 연관 관계에서 발생하던 N+1 문제를 해결
  - QueryDSL 쿼리에 fetchJoin 추가하여 연관 엔티티를 한 번에 조회되도록 개선
- 지연 로딩으로 인해 결제 요청 수만큼 추가 쿼리가 실행되던 성능 이슈 해결
- 응답 속도 개선 및 DB 커넥션 낭비 최소화

## 📝 참고사항
- 

## 📚 기타
-