### PR TITLE
refactor: PaymentEntity와 PaymentEventEntity 간 관계를 OneToOne으로 변경

### DIFF
--- a/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
+++ b/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
@@ -25,6 +25,7 @@ public class ExceptionCodeMapper {
         CONFLICT_MAP.put("동시성 저장은 불가능합니다.", "CONFLICT_EXCEPTION_002");
         CONFLICT_MAP.put("해당 벤더의 해당 카테고리 솔루션이 이미 존재합니다.", "CONFLICT_EXCEPTION_004");
         CONFLICT_MAP.put("같은 솔루션에 리뷰는 한 번만 작성할 수 있습니다.", "CONFLICT_EXCEPTION_005");
+        CONFLICT_MAP.put("이미 해당 결제 요청에 대한 결제 정보가 존재합니다. 새롭게 결제 요청을 진행해야합니다.", "CONFLICT_EXCEPTION_006");
 
         // NotFoundException
         NOT_FOUND_MAP.put("존재하지 않는 벤더 기업입니다.", "NOT_FOUND_EXCEPTION_001");

--- a/src/main/java/startwithco/startwithbackend/payment/payment/controller/PaymentController.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/controller/PaymentController.java
@@ -35,7 +35,7 @@ public class PaymentController {
             description = """
                     1. 광클 방지를 위한 disable 처리해주세요.
                     2. amount의 경우 부가세 포함한 가격을 보내야합니다.
-                    3. paymentKey의 경우 SuccessURL에서 받은 값, orderId의 경우 UUID 값을 생성해서 넘겨주셔야합니다.
+                    3. paymentKey의 경우 SuccessURL 에서 받은 값, orderId의 경우 UUID 값을 생성해서 넘겨주셔야합니다.
                     4. SERVER - TOSS 사이 간 orderId로 멱등성 처리가 돼 있습니다. 때문에 이전 결제 요청에서 결제 실패가 발생했을 경우 새로운 orderId 값을 만들어주셔야합니다.
                     5. 결제 실패 상황의 경우 웹훅 이벤트 URL 참고해주세요. (카드 결제: PAYMENT_STATUS_CHANGED, 가상 계좌: DEPOSIT_CALLBACK)
                     6. 가상 계좌의 경우 토스페이먼츠의 웹훅으로 인한 상태 변경 이후 즉시 클라이언트로 결과값 반환 예정입니다. **(FE 배포 후 웹훅 URL 생성 필요)**
@@ -53,6 +53,7 @@ public class PaymentController {
             @ApiResponse(responseCode = "BAD_REQUEST_EXCEPTION_008", description = "해당 결제 요청은 승인할 수 없습니다. 결제 승인 진행 중입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "BAD_REQUEST_EXCEPTION_009", description = "지원하지 않는 결제 수단입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "SERVER_EXCEPTION_003", description = "결제 응답 파싱 중 오류가 발생했습니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "CONFLICT_EXCEPTION_006", description = "이미 해당 결제 요청에 대한 결제 정보가 존재합니다. 새롭게 결제 요청을 진행해야합니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
     })
     public Mono<ResponseEntity<BaseResponse<?>>> tossPaymentApproval(@RequestBody TossPaymentApprovalRequest request) {
         request.validate();

--- a/src/main/java/startwithco/startwithbackend/payment/payment/domain/PaymentEntity.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/domain/PaymentEntity.java
@@ -24,7 +24,7 @@ public class PaymentEntity extends BaseTimeEntity {
     @Column(name = "payment_seq")
     private Long paymentSeq;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "payment_event_seq", nullable = false)
     private PaymentEventEntity paymentEventEntity;
 

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/controller/PaymentEventController.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/controller/PaymentEventController.java
@@ -42,6 +42,7 @@ public class PaymentEventController {
             description = """
                     1. 광클 방지를 위한 disable 처리해주세요.
                     2. amount는 1보다 작을 수 없습니다.
+                    3. 만약 해당 결제 요청을 통해 결제 승인을 진행한 경우 다시 결제를 진행하려면 새로운 결제 요청하기를 생성해야합니다.
                     """
     )
     @ApiResponses(value = {
@@ -80,11 +81,10 @@ public class PaymentEventController {
     @Operation(
             summary = "결제 요청하기 조회 API",
             description = """
-                    1. 광클 방지를 위한 disable 처리해주세요.
-                    2. category: BI, BPM, CMS, CRM, DMS, EAM, ECM, ERP, HR, HRM, KM, SCM, SI, SECURITY
-                    3. 결제 승인되지 않았을 때의 Response
+                    1. category: BI, BPM, CMS, CRM, DMS, EAM, ECM, ERP, HR, HRM, KM, SCM, SI, SECURITY
+                    2. 결제 승인되지 않았을 때의 Response
                         - GetCONFIRMEDPaymentEventEntityResponse
-                    4. 결제 승인 됐을 때의 Response
+                    3. 결제 승인 됐을 때의 Response
                         - GetREQUESTEDPaymentEventEntityResponse
                     """
     )

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/controller/response/PaymentEventResponse.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/controller/response/PaymentEventResponse.java
@@ -26,6 +26,7 @@ public class PaymentEventResponse {
     public record GetCONFIRMEDPaymentEventEntityResponse(
             Long paymentEventSeq,
             String paymentEventName,
+            String orderId,
             CATEGORY category,
             Long amount,
             LocalDateTime createdAt,

--- a/src/main/java/startwithco/startwithbackend/payment/paymentEvent/service/PaymentEventService.java
+++ b/src/main/java/startwithco/startwithbackend/payment/paymentEvent/service/PaymentEventService.java
@@ -119,6 +119,7 @@ public class PaymentEventService {
                 result.add(new GetCONFIRMEDPaymentEventEntityResponse(
                         event.getPaymentEventSeq(),
                         event.getPaymentEventName(),
+                        payment.getOrderId(),
                         event.getSolutionEntity().getCategory(),
                         payment.getAmount(),
                         event.getCreatedAt(),

--- a/src/main/java/startwithco/startwithbackend/solution/solution/controller/SolutionController.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/controller/SolutionController.java
@@ -44,11 +44,11 @@ public class SolutionController {
     @Operation(
             summary = "솔루션 생성 API",
             description = """
-                    1. 광클 방지를 위한 disable 처리해주세요.\n
-                    2. 중복 가능한 데이터의 경우 ','로 이어서 String으로 보내주세요. EX) 소기업,중기업,중견기업\n
-                    3. category: BI, BPM, CMS, CRM, DMS, EAM, ECM, ERP, HR, HRM, KM, SCM, SI, SECURITY\n
-                    4. DIRECTION: INCREASE, DECREASE\n
-                    5. amount는 1보다 작을 수 없습니다.\n
+                    1. 광클 방지를 위한 disable 처리해주세요.
+                    2. 중복 가능한 데이터의 경우 ','로 이어서 String으로 보내주세요. EX) 소기업,중기업,중견기업
+                    3. category: BI, BPM, CMS, CRM, DMS, EAM, ECM, ERP, HR, HRM, KM, SCM, SI, SECURITY
+                    4. DIRECTION: INCREASE, DECREASE
+                    5. amount는 1보다 작을 수 없습니다.
                     """
     )
     @ApiResponses(value = {
@@ -88,11 +88,11 @@ public class SolutionController {
     @Operation(
             summary = "솔루션 수정 API",
             description = """
-                    1. 광클 방지를 위한 disable 처리해주세요.\n
-                    2. 중복 가능한 데이터의 경우 ','로 이어서 String으로 보내주세요. EX) 소기업,중기업,중견기업\n
-                    3. category: BI, BPM, CMS, CRM, DMS, EAM, ECM, ERP, HR, HRM, KM, SCM, SI, SECURITY\n
-                    4. DIRECTION: INCREASE, DECREASE\n
-                    5. amount는 1보다 작을 수 없습니다.\n
+                    1. 광클 방지를 위한 disable 처리해주세요.
+                    2. 중복 가능한 데이터의 경우 ','로 이어서 String으로 보내주세요. EX) 소기업,중기업,중견기업
+                    3. category: BI, BPM, CMS, CRM, DMS, EAM, ECM, ERP, HR, HRM, KM, SCM, SI, SECURITY
+                    4. DIRECTION: INCREASE, DECREASE
+                    5. amount는 1보다 작을 수 없습니다.
                     """
     )
     @ApiResponses(value = {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- PaymentEntity.paymentEventEntity를 @ManyToOne → @OneToOne(fetch = LAZY)으로 변경
- 결제 요청(PaymentEventEntity)당 하나의 결제 승인(PaymentEntity)만 허용되도록 제약 강화
- 중복 저장 시 DataIntegrityViolationException 발생 가능성 고려
- 관련 조회 로직(getPaymentEventEntity)에서 단건 조인 기준으로 동작함을 전제

## 📝 참고사항
- 

## 📚 기타
-