### PR TITLE
fix: CORS 설정 수정 (credentials false 및 모든 Origin 허용)

### DIFF
--- a/src/main/java/startwithco/startwithbackend/config/SecurityConfiguration.java
+++ b/src/main/java/startwithco/startwithbackend/config/SecurityConfiguration.java
@@ -54,7 +54,8 @@ public class SecurityConfiguration {
         configuration.setAllowedOriginPatterns(List.of("*"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
-        configuration.setAllowCredentials(true);
+        configuration.setAllowCredentials(false);
+        configuration.setAllowedOriginPatterns(List.of("*"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

- setAllowCredentials(false)로 설정하여 쿠키 인증 미사용 명시
- setAllowedOriginPatterns("*") 구성 유지하여 모든 Origin 허용
- JWT 기반 인증 방식에 맞춰 CORS 정책 일치시킴

## 📝 참고사항
- 

## 📚 기타
-