### PR TITLE
feat: 예외 로그 요청 본문(JSON) 이중 구조 파싱 및 예쁘게 출력

### DIFF
--- a/src/main/java/startwithco/startwithbackend/exception/BadRequestException.java
+++ b/src/main/java/startwithco/startwithbackend/exception/BadRequestException.java
@@ -1,12 +1,10 @@
 package startwithco.startwithbackend.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class BadRequestException extends RuntimeException {
-	private final int httpStatus;
-	private final String message;
-	private final String code;
+public class BadRequestException  extends CustomBaseException {
+    public BadRequestException(int httpStatus, String message, String code) {
+        super(message, httpStatus, code);
+    }
 }

--- a/src/main/java/startwithco/startwithbackend/exception/ConflictException.java
+++ b/src/main/java/startwithco/startwithbackend/exception/ConflictException.java
@@ -1,12 +1,10 @@
 package startwithco.startwithbackend.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class ConflictException extends RuntimeException {
-	private final int httpStatus;
-	private final String message;
-	private final String code;
+public class ConflictException  extends CustomBaseException {
+    public ConflictException(int httpStatus, String message, String code) {
+        super(message, httpStatus, code);
+    }
 }

--- a/src/main/java/startwithco/startwithbackend/exception/CustomBaseException.java
+++ b/src/main/java/startwithco/startwithbackend/exception/CustomBaseException.java
@@ -1,0 +1,15 @@
+package startwithco.startwithbackend.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class CustomBaseException extends RuntimeException {
+    private final int httpStatus;
+    private final String code;
+
+    protected CustomBaseException(String message, int httpStatus, String code) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.code = code;
+    }
+}

--- a/src/main/java/startwithco/startwithbackend/exception/NotFoundException.java
+++ b/src/main/java/startwithco/startwithbackend/exception/NotFoundException.java
@@ -1,12 +1,10 @@
 package startwithco.startwithbackend.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class NotFoundException extends RuntimeException {
-    private final int httpStatus;
-    private final String message;
-    private final String code;
+public class NotFoundException  extends CustomBaseException {
+    public NotFoundException(int httpStatus, String message, String code) {
+        super(message, httpStatus, code);
+    }
 }

--- a/src/main/java/startwithco/startwithbackend/exception/ServerException.java
+++ b/src/main/java/startwithco/startwithbackend/exception/ServerException.java
@@ -1,12 +1,10 @@
 package startwithco.startwithbackend.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class ServerException extends RuntimeException {
-    private final int httpStatus;
-    private final String message;
-    private final String code;
+public class ServerException  extends CustomBaseException {
+    public ServerException(int httpStatus, String message, String code) {
+        super(message, httpStatus, code);
+    }
 }

--- a/src/main/java/startwithco/startwithbackend/exception/UnauthorizedException.java
+++ b/src/main/java/startwithco/startwithbackend/exception/UnauthorizedException.java
@@ -1,12 +1,10 @@
 package startwithco.startwithbackend.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class UnauthorizedException extends RuntimeException {
-    private final int httpStatus;
-    private final String message;
-    private final String code;
+public class UnauthorizedException extends CustomBaseException {
+    public UnauthorizedException(int httpStatus, String message, String code) {
+        super(message, httpStatus, code);
+    }
 }

--- a/src/main/java/startwithco/startwithbackend/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/startwithco/startwithbackend/exception/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package startwithco.startwithbackend.exception.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,50 +11,96 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import startwithco.startwithbackend.exception.*;
 import startwithco.startwithbackend.log.service.ExceptionLogService;
 
+import java.io.BufferedReader;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
     private final ExceptionLogService exceptionLogService;
 
-    @ExceptionHandler({ServerException.class})
-    public ResponseEntity<ErrorResponse> handleServerException(final ServerException exception, HttpServletRequest request) {
-        exceptionLogService.saveExceptionLogEntity(exception, exception.getHttpStatus(), exception.getCode(), request.getRequestURI());
+    @ExceptionHandler({ServerException.class, BadRequestException.class, NotFoundException.class, UnauthorizedException.class, ConflictException.class})
+    public ResponseEntity<ErrorResponse> handleCustomException(final RuntimeException exception, final HttpServletRequest request) {
 
-        return ResponseEntity.status(exception.getHttpStatus())
-                .body(new ErrorResponse(exception.getHttpStatus(), exception.getMessage(), exception.getCode()));
+        if (exception instanceof CustomBaseException ex) {
+            String methodName = ex.getStackTrace().length > 0
+                    ? ex.getStackTrace()[0].toString()
+                    : "UNKNOWN";
+
+            String requestBody = getRequestBody(request);
+
+            exceptionLogService.saveExceptionLogEntity(
+                    ex.getHttpStatus(),
+                    ex.getCode(),
+                    ex.getMessage(),
+                    request.getRequestURI(),
+                    methodName,
+                    requestBody
+            );
+
+            return ResponseEntity.status(ex.getHttpStatus())
+                    .body(new ErrorResponse(ex.getHttpStatus(), ex.getMessage(), ex.getCode()));
+        }
+
+        log.error("Unhandled exception caught: ", exception);
+        return ResponseEntity.status(500)
+                .body(new ErrorResponse(500, "서버 내부 오류", "INTERNAL_SERVER_ERROR"));
     }
 
-    @ExceptionHandler({BadRequestException.class})
-    public ResponseEntity<ErrorResponse> handleBadRequestException(final BadRequestException exception, HttpServletRequest request) {
-        exceptionLogService.saveExceptionLogEntity(exception, exception.getHttpStatus(), exception.getCode(), request.getRequestURI());
+    private String getRequestBody(HttpServletRequest request) {
+        try {
+            String contentType = request.getContentType();
+            ObjectMapper mapper = new ObjectMapper();
 
-        return ResponseEntity.status(exception.getHttpStatus())
-                .body(new ErrorResponse(exception.getHttpStatus(), exception.getMessage(), exception.getCode()));
-    }
+            if (contentType != null && contentType.contains("application/json")) {
+                StringBuilder sb = new StringBuilder();
+                try (BufferedReader reader = request.getReader()) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        sb.append(line);
+                    }
+                }
 
-    @ExceptionHandler({NotFoundException.class})
-    public ResponseEntity<ErrorResponse> handleNotFoundException(final NotFoundException exception, HttpServletRequest request) {
-        exceptionLogService.saveExceptionLogEntity(exception, exception.getHttpStatus(), exception.getCode(), request.getRequestURI());
+                String raw = sb.toString();
+                if (raw.isBlank()) return "[본문 없음]";
 
-        return ResponseEntity.status(exception.getHttpStatus())
-                .body(new ErrorResponse(exception.getHttpStatus(), exception.getMessage(), exception.getCode()));
-    }
+                Map<String, Object> json = mapper.readValue(raw, Map.class);
+                Object requestData = json.get("request");
 
-    @ExceptionHandler({UnauthorizedException.class})
-    public ResponseEntity<ErrorResponse> handleNotFoundException(final UnauthorizedException exception, HttpServletRequest request) {
-        exceptionLogService.saveExceptionLogEntity(exception, exception.getHttpStatus(), exception.getCode(), request.getRequestURI());
+                if (requestData instanceof String str) {
+                    try {
+                        Object nested = mapper.readValue(str, Object.class);
+                        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(nested);
+                    } catch (Exception e) {
+                        return str;
+                    }
+                }
 
-        return ResponseEntity.status(exception.getHttpStatus())
-                .body(new ErrorResponse(exception.getHttpStatus(), exception.getMessage(), exception.getCode()));
-    }
+                if (requestData != null) {
+                    return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(requestData);
+                }
 
-    @ExceptionHandler({ConflictException.class})
-    public ResponseEntity<ErrorResponse> handleNotFoundException(final ConflictException exception, HttpServletRequest request) {
-        exceptionLogService.saveExceptionLogEntity(exception, exception.getHttpStatus(), exception.getCode(), request.getRequestURI());
+                return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
+            } else {
+                Map<String, String[]> paramMap = request.getParameterMap();
+                if (paramMap.isEmpty()) return "[본문 없음]";
 
-        return ResponseEntity.status(exception.getHttpStatus())
-                .body(new ErrorResponse(exception.getHttpStatus(), exception.getMessage(), exception.getCode()));
+                Map<String, Object> resultMap = new LinkedHashMap<>();
+                for (Map.Entry<String, String[]> entry : paramMap.entrySet()) {
+                    String key = entry.getKey();
+                    String[] values = entry.getValue();
+                    resultMap.put(key, values.length == 1 ? values[0] : Arrays.asList(values));
+                }
+
+                return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(resultMap);
+            }
+        } catch (Exception e) {
+            return "[본문 추출 실패]";
+        }
     }
 
     @Getter

--- a/src/main/java/startwithco/startwithbackend/log/controller/ExceptionLogController.java
+++ b/src/main/java/startwithco/startwithbackend/log/controller/ExceptionLogController.java
@@ -1,5 +1,7 @@
 package startwithco.startwithbackend.log.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -24,13 +26,58 @@ public class ExceptionLogController {
         int start = page * pageSize;
         int end = start + pageSize;
 
+        ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
         try {
-            List<ExceptionLogDto> exceptionLogDtos = exceptionLogService.getAllExceptionLogEntity(start, end);
+            List<ExceptionLogDto> exceptionLogDtos = exceptionLogService.getAllExceptionLogEntity(start, end)
+                    .stream()
+                    .map(dto -> {
+                        String raw = dto.getRequestBody();
+                        String pretty = raw;
+
+                        try {
+                            if (raw != null && raw.trim().startsWith("{")) {
+                                var root = objectMapper.readTree(raw);
+
+                                // case 1: "request" 키가 있고, 그 값이 JSON 문자열이라면 → 이중 파싱
+                                if (root.has("request") && root.get("request").isTextual()) {
+                                    String nestedStr = root.get("request").asText();
+
+                                    try {
+                                        var nestedJson = objectMapper.readTree(nestedStr);
+                                        pretty = objectMapper.writerWithDefaultPrettyPrinter()
+                                                .writeValueAsString(nestedJson);
+                                    } catch (Exception e) {
+                                        pretty = nestedStr;
+                                    }
+
+                                } else {
+                                    // case 2: 일반 JSON 객체 → 바로 예쁘게 출력
+                                    pretty = objectMapper.writerWithDefaultPrettyPrinter()
+                                            .writeValueAsString(root);
+                                }
+                            }
+                        } catch (Exception e) {
+                            // JSON 파싱 실패 → 원본 그대로
+                        }
+
+                        return new ExceptionLogDto(
+                                dto.getCreatedAt(),
+                                dto.getHttpStatus(),
+                                dto.getErrorCode(),
+                                dto.getMessage(),
+                                dto.getRequestUri(),
+                                pretty,
+                                dto.getMethodName()
+                        );
+                    })
+                    .toList();
+
             model.addAttribute("exceptionLogs", exceptionLogDtos);
             model.addAttribute("hasNext", exceptionLogDtos.size() == pageSize);
         } catch (Exception e) {
             model.addAttribute("errorMessage", e.getMessage());
-            model.addAttribute("payments", List.of());
+            model.addAttribute("exceptionLogs", List.of());
             model.addAttribute("hasNext", false);
         }
 

--- a/src/main/java/startwithco/startwithbackend/log/domain/ExceptionLogEntity.java
+++ b/src/main/java/startwithco/startwithbackend/log/domain/ExceptionLogEntity.java
@@ -19,9 +19,6 @@ public class ExceptionLogEntity extends BaseTimeEntity {
     @Column(name = "exception_log_seq")
     private Long exceptionLogSeq;
 
-    @Column(name = "exception_type", nullable = false)
-    private String exceptionType;
-
     @Column(name = "http_status", nullable = false)
     private int httpStatus;
 
@@ -34,6 +31,9 @@ public class ExceptionLogEntity extends BaseTimeEntity {
 
     @Column(name = "request_uri", nullable = false)
     private String requestUri;
+
+    @Column(name = "request_body", nullable = false, columnDefinition = "LONGTEXT")
+    private String requestBody;
 
     @Lob
     @Column(name = "method_name", nullable = false, columnDefinition = "LONGTEXT")

--- a/src/main/java/startwithco/startwithbackend/log/dto/ExceptionLogDto.java
+++ b/src/main/java/startwithco/startwithbackend/log/dto/ExceptionLogDto.java
@@ -9,10 +9,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ExceptionLogDto {
     private LocalDateTime createdAt;
-    private String exceptionType;
     private int httpStatus;
     private String errorCode;
     private String message;
     private String requestUri;
+    private String requestBody;
     private String methodName;
 }

--- a/src/main/java/startwithco/startwithbackend/log/service/ExceptionLogService.java
+++ b/src/main/java/startwithco/startwithbackend/log/service/ExceptionLogService.java
@@ -6,8 +6,6 @@ import startwithco.startwithbackend.log.domain.ExceptionLogEntity;
 import startwithco.startwithbackend.log.dto.ExceptionLogDto;
 import startwithco.startwithbackend.log.repository.ExceptionLogEntityRepository;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,19 +14,14 @@ import java.util.stream.Collectors;
 public class ExceptionLogService {
     private final ExceptionLogEntityRepository exceptionLogEntityRepository;
 
-    public void saveExceptionLogEntity(Exception exception, int status, String code, String uri) {
-        StringWriter sw = new StringWriter();
-        exception.printStackTrace(new PrintWriter(sw));
-        StackTraceElement[] stackTrace = exception.getStackTrace();
-        String methodName = stackTrace.length > 0 ? stackTrace[0].toString() : "UNKNOWN";
-
+    public void saveExceptionLogEntity(int status, String code, String message, String uri, String methodName, String logDetail) {
         ExceptionLogEntity exceptionLogEntity = ExceptionLogEntity.builder()
-                .exceptionType(exception.getClass().getSimpleName())
                 .httpStatus(status)
                 .errorCode(code)
-                .message(exception.getMessage())
+                .message(message)
                 .requestUri(uri)
                 .methodName(methodName)
+                .requestBody(logDetail)
                 .build();
 
         exceptionLogEntityRepository.saveExceptionLogEntity(exceptionLogEntity);
@@ -38,11 +31,11 @@ public class ExceptionLogService {
         return exceptionLogEntityRepository.findAll(start, end).stream()
                 .map(log -> new ExceptionLogDto(
                         log.getCreatedAt(),
-                        log.getExceptionType(),
                         log.getHttpStatus(),
                         log.getErrorCode(),
                         log.getMessage(),
                         log.getRequestUri(),
+                        log.getRequestBody(),
                         log.getMethodName()
                 ))
                 .collect(Collectors.toList());

--- a/src/main/resources/templates/log.html
+++ b/src/main/resources/templates/log.html
@@ -79,6 +79,18 @@
             pointer-events: none;
             border-color: #eee;
         }
+
+        pre {
+            text-align: left;
+            font-size: 11px;
+            white-space: pre-wrap;
+            background-color: #f9f9f9;
+            padding: 4px;
+            border: 1px solid #eee;
+            border-radius: 4px;
+            max-height: 200px;
+            overflow-y: auto;
+        }
     </style>
 </head>
 <body>
@@ -93,22 +105,24 @@
     <thead>
     <tr>
         <th>시간</th>
-        <th>예외 클래스명</th>
         <th>HTTP 상태 코드</th>
         <th>서비스 내부에서 정의한 예외 코드</th>
         <th>예외 메시지</th>
         <th>요청 URI</th>
+        <th>요청 REQUEST</th>
         <th>발생 Method</th>
     </tr>
     </thead>
     <tbody>
-    <tr th:each="log : ${exceptionLogs}">
+    <tr th:each="log, iterStat : ${exceptionLogs}">
         <td th:text="${log.createdAt != null ? #temporals.format(log.createdAt, 'yyyy-MM-dd HH:mm:ss') : '-'}">-</td>
-        <td th:text="${log.exceptionType ?: '-'}">-</td>
         <td th:text="${log.httpStatus ?: '-'}">-</td>
         <td th:text="${log.errorCode ?: '-'}">-</td>
         <td th:text="${log.message ?: '-'}">-</td>
         <td th:text="${log.requestUri ?: '-'}">-</td>
+        <td>
+            <pre th:utext="${log.requestBody ?: '-'}">-</pre>
+        </td>
         <td th:text="${log.methodName ?: '-'}">-</td>
     </tr>
     </tbody>


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- GlobalExceptionHandler에서 JSON 요청 본문 내 "request" 필드가 JSON 문자열일 경우 이를 파싱하여 저장
- ExceptionLogController에서 requestBody가 이중 JSON 구조일 경우 내부 문자열까지 파싱하여 Pretty Print 처리
- HTML에서 자바스크립트 제거하고 <pre th:utext>로 출력만 하도록 단순화
- 이중 JSON 구조가 포함된 로그도 가독성 있게 출력되도록 개선

## 📝 참고사항
- 

## 📚 기타
-