### PR TITLE
feat: 사용자 seq 기반 카테고리 구분 조회 기능 추가

### DIFF
--- a/src/main/java/startwithco/startwithbackend/b2b/dashboard/controller/DashBoardController.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/dashboard/controller/DashBoardController.java
@@ -13,13 +13,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import startwithco.startwithbackend.b2b.consumer.controller.response.ConsumerResponse;
 import startwithco.startwithbackend.b2b.consumer.service.ConsumerService;
-import startwithco.startwithbackend.b2b.vendor.controller.response.VendorResponse;
 import startwithco.startwithbackend.b2b.vendor.service.VendorService;
 import startwithco.startwithbackend.base.BaseResponse;
 import startwithco.startwithbackend.exception.BadRequestException;
-import startwithco.startwithbackend.exception.code.ExceptionCodeMapper;
 import startwithco.startwithbackend.exception.handler.GlobalExceptionHandler;
 import startwithco.startwithbackend.payment.payment.util.PAYMENT_STATUS;
 

--- a/src/main/java/startwithco/startwithbackend/b2b/home/controller/HomeController.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/home/controller/HomeController.java
@@ -1,0 +1,60 @@
+package startwithco.startwithbackend.b2b.home.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import startwithco.startwithbackend.base.BaseResponse;
+import startwithco.startwithbackend.exception.BadRequestException;
+import startwithco.startwithbackend.exception.handler.GlobalExceptionHandler;
+import startwithco.startwithbackend.solution.solution.service.SolutionService;
+
+import static startwithco.startwithbackend.b2b.home.controller.response.HomeResponse.*;
+import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.*;
+import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.getCode;
+
+@RestController
+@RequestMapping("/api/b2b-service/home")
+@Tag(name = "홈 화면", description = "담당자(박종훈)")
+@RequiredArgsConstructor
+public class HomeController {
+    private final SolutionService solutionService;
+
+    @GetMapping(
+            name = "도입 완료, 도입 예정된 솔루션"
+    )
+    @Operation(
+            summary = "도입 완료, 도입 예정된 솔루션",
+            description = """
+                    1. category: BI, BPM, CMS, CRM, DMS, EAM, ECM, ERP, HR, HRM, KM, SCM, SI, SECURITY
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "SUCCESS", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "SERVER_EXCEPTION_001", description = "내부 서버 오류가 발생했습니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "BAD_REQUEST_EXCEPTION_001", description = "요청 데이터 오류입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "NOT_FOUND_EXCEPTION_012", description = "존재하지 않는 사용자입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+    })
+    public ResponseEntity<BaseResponse<HomeCategoryResponse>> getCategory(@RequestParam(value = "seq", required = false) Long seq) {
+        if (seq == null) {
+            throw new BadRequestException(
+                    HttpStatus.BAD_REQUEST.value(),
+                    "요청 데이터 오류입니다.",
+                    getCode("요청 데이터 오류입니다.", ExceptionType.BAD_REQUEST)
+            );
+        }
+
+        HomeCategoryResponse response = solutionService.getCategory(seq);
+
+        return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), response));
+    }
+}

--- a/src/main/java/startwithco/startwithbackend/b2b/home/controller/response/HomeResponse.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/home/controller/response/HomeResponse.java
@@ -1,0 +1,14 @@
+package startwithco.startwithbackend.b2b.home.controller.response;
+
+import startwithco.startwithbackend.solution.solution.util.CATEGORY;
+
+import java.util.List;
+
+public class HomeResponse {
+    public record HomeCategoryResponse(
+            List<CATEGORY> used,
+            List<CATEGORY> unused
+    ) {
+
+    }
+}

--- a/src/main/java/startwithco/startwithbackend/b2b/vendor/controller/VendorController.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/vendor/controller/VendorController.java
@@ -16,8 +16,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import startwithco.startwithbackend.b2b.consumer.controller.request.ConsumerRequest;
-import startwithco.startwithbackend.b2b.consumer.controller.response.ConsumerResponse;
 import startwithco.startwithbackend.b2b.vendor.service.VendorService;
 import startwithco.startwithbackend.base.BaseResponse;
 import startwithco.startwithbackend.exception.BadRequestException;

--- a/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
+++ b/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
@@ -41,6 +41,7 @@ public class ExceptionCodeMapper {
         NOT_FOUND_MAP.put("존재하지 않는 이메일 입니다.", "NOT_FOUND_EXCEPTION_009");
         NOT_FOUND_MAP.put("전송자가 수요/벤더 기업에 존재하지 않습니다.", "NOT_FOUND_EXCEPTION_010");
         NOT_FOUND_MAP.put("수신자가 수요/벤더 기업에 존재하지 않습니다.", "NOT_FOUND_EXCEPTION_011");
+        NOT_FOUND_MAP.put("존재하지 않는 사용자입니다.", "NOT_FOUND_EXCEPTION_012");
 
         // ServerException
         SERVER_MAP.put("내부 서버 오류가 발생했습니다.", "SERVER_EXCEPTION_001");

--- a/src/main/java/startwithco/startwithbackend/payment/payment/controller/PaymentController.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/controller/PaymentController.java
@@ -77,7 +77,7 @@ public class PaymentController {
                     3. 환불의 경우 24이내 3가지(카드 결제 취소, 가상 계좌 입금 전, 가상 계좌 입금 후)가 존재합니다.
                     5. 가상 계좌 입금 전의 경우 결제 승인이 이루어지지 않았기 때문에 가상 계좌 요청 24시간 이내를 기준으로 계산합니다.
                     6. 24시간이 지난 가상 계좌 입금의 경우 서버에서 자동으로 결제 취소 처리합니다.
-                    7. 카드 결제 취소와 가상 계좌 입금 전의 경우 paymentEventSeq 값만 넘겨주시면 됩니다.
+                    7. **카드 결제 취소와 가상 계좌 입금 전의 경우 paymentEventSeq 값만 넘겨주시면 됩니다.**
                     8. 가상 계좌 입금 후의 경우 bankCode(은행, 증권사 코드), accountNumber(환불 받을 계좌 번호), holderName(예금주)를 같이 넘겨야합니다.
                     9. 다음 은행 코드 중 하나를 사용해야 하며, 문자열 형태로 전달됩니다.
                        - 03: IBK기업은행
@@ -122,7 +122,11 @@ public class PaymentController {
 
     @PostMapping(
             value = "/deposit-callback"
-    ) public ResponseEntity<BaseResponse<String>> tossPaymentDepositCallBack(@RequestBody TossPaymentDepositCallBackRequest request) {
+    )
+    @Operation(
+            hidden = true
+    )
+    public ResponseEntity<BaseResponse<String>> tossPaymentDepositCallBack(@RequestBody TossPaymentDepositCallBackRequest request) {
         paymentService.tossPaymentDepositCallBack(request);
 
         return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), "SUCCESS"));

--- a/src/main/java/startwithco/startwithbackend/solution/solution/repository/SolutionEntityJpaRepository.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/repository/SolutionEntityJpaRepository.java
@@ -5,17 +5,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import startwithco.startwithbackend.solution.solution.domain.SolutionEntity;
-import startwithco.startwithbackend.solution.solution.util.CATEGORY;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SolutionEntityJpaRepository extends JpaRepository<SolutionEntity, Long> {
-    @Query("SELECT s FROM SolutionEntity s WHERE s.vendorEntity.vendorSeq = :vendorSeq AND s.category = :category")
-    Optional<SolutionEntity> findByVendorSeqAndCategory(@Param("vendorSeq") Long vendorSeq, @Param("category") CATEGORY category);
-
-    @Query("SELECT s FROM SolutionEntity s WHERE s.vendorEntity.vendorSeq = :vendorSeq")
+    @Query("""
+            SELECT s
+            FROM SolutionEntity s
+            WHERE s.vendorEntity.vendorSeq = :vendorSeq
+            """)
     List<SolutionEntity> findAllByVendorSeq(@Param("vendorSeq") Long vendorSeq);
 
     @Query("""

--- a/src/main/java/startwithco/startwithbackend/solution/solution/repository/SolutionEntityRepository.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/repository/SolutionEntityRepository.java
@@ -4,6 +4,7 @@ import startwithco.startwithbackend.solution.solution.domain.SolutionEntity;
 import startwithco.startwithbackend.solution.solution.util.CATEGORY;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface SolutionEntityRepository {
@@ -16,4 +17,6 @@ public interface SolutionEntityRepository {
     Optional<SolutionEntity> findBySolutionSeq(Long solutionSeq);
 
     List<SolutionEntity> findBySpecialistAndCategoryAndIndustryAndBudgetAndKeyword(String specialist, CATEGORY category, String industry, String budget, String keyword, int start, int end);
+
+    Map<String, List<CATEGORY>> findUsedAndUnusedCategories();
 }

--- a/src/main/java/startwithco/startwithbackend/solution/solution/repository/SolutionEntityRepositoryImpl.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/repository/SolutionEntityRepositoryImpl.java
@@ -2,6 +2,7 @@ package startwithco.startwithbackend.solution.solution.repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
@@ -12,7 +13,9 @@ import startwithco.startwithbackend.solution.solution.domain.QSolutionEntity;
 import startwithco.startwithbackend.solution.solution.domain.SolutionEntity;
 import startwithco.startwithbackend.solution.solution.util.CATEGORY;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.getCode;
@@ -22,6 +25,7 @@ import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.ge
 public class SolutionEntityRepositoryImpl implements SolutionEntityRepository {
     private final SolutionEntityJpaRepository repository;
     private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
 
     public SolutionEntity saveSolutionEntity(SolutionEntity solutionEntity) {
         return repository.save(solutionEntity);
@@ -116,5 +120,22 @@ public class SolutionEntityRepositoryImpl implements SolutionEntityRepository {
                 .offset(start)
                 .limit(end - start)
                 .fetch();
+    }
+
+    @Override
+    public Map<String, List<CATEGORY>> findUsedAndUnusedCategories() {
+        List<CATEGORY> usedCategories = em.createQuery(
+                "SELECT DISTINCT s.category FROM SolutionEntity s", CATEGORY.class
+        ).getResultList();
+
+        List<CATEGORY> allCategories = Arrays.asList(CATEGORY.values());
+        List<CATEGORY> unusedCategories = allCategories.stream()
+                .filter(category -> !usedCategories.contains(category))
+                .toList();
+
+        return Map.of(
+                "used", usedCategories,
+                "unused", unusedCategories
+        );
     }
 }

--- a/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
@@ -7,9 +7,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import startwithco.startwithbackend.b2b.consumer.domain.ConsumerEntity;
+import startwithco.startwithbackend.b2b.consumer.repository.ConsumerRepository;
+import startwithco.startwithbackend.b2b.home.controller.response.HomeResponse;
 import startwithco.startwithbackend.b2b.vendor.domain.VendorEntity;
 import startwithco.startwithbackend.b2b.vendor.repository.VendorEntityRepository;
 import startwithco.startwithbackend.exception.ServerException;
+import startwithco.startwithbackend.exception.code.ExceptionCodeMapper;
 import startwithco.startwithbackend.solution.review.repository.SolutionReviewEntityRepository;
 import startwithco.startwithbackend.solution.solution.util.CATEGORY;
 import startwithco.startwithbackend.solution.effect.util.DIRECTION;
@@ -26,9 +30,11 @@ import startwithco.startwithbackend.common.service.CommonService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static startwithco.startwithbackend.b2b.home.controller.response.HomeResponse.*;
 import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.*;
 import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.getCode;
 import static startwithco.startwithbackend.solution.solution.controller.request.SolutionRequest.*;
@@ -40,6 +46,7 @@ import static startwithco.startwithbackend.solution.solution.controller.response
 @Slf4j
 public class SolutionService {
     private final VendorEntityRepository vendorEntityRepository;
+    private final ConsumerRepository consumerEntityRepository;
     private final SolutionEntityRepository solutionEntityRepository;
     private final SolutionEffectEntityRepository solutionEffectEntityRepository;
     private final SolutionKeywordEntityRepository solutionKeywordEntityRepository;
@@ -247,5 +254,26 @@ public class SolutionService {
         }
 
         return response;
+    }
+
+    @Transactional(readOnly = true)
+    public HomeCategoryResponse getCategory(Long seq) {
+        Optional<ConsumerEntity> consumerEntity = consumerEntityRepository.findByConsumerSeq(seq);
+        Optional<VendorEntity> vendorEntity = vendorEntityRepository.findByVendorSeq(seq);
+
+        if (consumerEntity.isEmpty() && vendorEntity.isEmpty()) {
+            throw new NotFoundException(
+                    HttpStatus.NOT_FOUND.value(),
+                    "존재하지 않는 사용자입니다.",
+                    getCode("존재하지 않는 사용자입니다.", ExceptionType.NOT_FOUND)
+            );
+        }
+
+        Map<String, List<CATEGORY>> result = solutionEntityRepository.findUsedAndUnusedCategories();
+
+        return new HomeCategoryResponse(
+                result.getOrDefault("used", List.of()),
+                result.getOrDefault("unused", List.of())
+        );
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- ConsumerEntity와 VendorEntity 중 하나라도 존재하는지 확인
- 존재하지 않을 경우 404 NOT_FOUND 예외 처리 적용
- 사용된 CATEGORY와 사용되지 않은 CATEGORY를 Map 기반으로 분류
- HomeCategoryResponse DTO를 사용해 used, unused 카테고리 반환

## 📝 참고사항
- 

## 📚 기타
-