### PR TITLE
feat: 벤더 통계 조회 로직 구현

### DIFF
--- a/src/main/java/startwithco/startwithbackend/b2b/stat/controller/StatController.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/stat/controller/StatController.java
@@ -1,0 +1,53 @@
+package startwithco.startwithbackend.b2b.stat.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import startwithco.startwithbackend.b2b.stat.service.StatService;
+import startwithco.startwithbackend.base.BaseResponse;
+import startwithco.startwithbackend.exception.BadRequestException;
+import startwithco.startwithbackend.exception.code.ExceptionCodeMapper;
+import startwithco.startwithbackend.exception.handler.GlobalExceptionHandler;
+
+import static startwithco.startwithbackend.b2b.stat.controller.response.StatResponse.*;
+import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.getCode;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/b2b-service/stat")
+@Tag(name = "통계 자료", description = "담당자(박종훈)")
+public class StatController {
+    private final StatService statService;
+
+    @GetMapping(name = "통계 자료 조회")
+    @Operation(summary = "통계 자료 조회 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "SUCCESS", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "SERVER_EXCEPTION_001", description = "내부 서버 오류가 발생했습니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "BAD_REQUEST_EXCEPTION_001", description = "요청 데이터 오류입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "NOT_FOUND_EXCEPTION_004", description = "존재하지 않는 수요 기업입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+    })
+    public ResponseEntity<BaseResponse<GetVendorStatResponse>> getStatEntity(@RequestParam(name = "vendorSeq", required = false) Long vendorSeq) {
+        if (vendorSeq == null) {
+            throw new BadRequestException(
+                    HttpStatus.BAD_REQUEST.value(),
+                    "요청 데이터 오류입니다.",
+                    getCode("요청 데이터 오류입니다.", ExceptionCodeMapper.ExceptionType.BAD_REQUEST)
+            );
+        }
+
+        GetVendorStatResponse response = statService.getStatEntity(vendorSeq);
+
+        return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), response));
+    }
+}

--- a/src/main/java/startwithco/startwithbackend/b2b/stat/controller/response/StatResponse.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/stat/controller/response/StatResponse.java
@@ -1,0 +1,17 @@
+package startwithco.startwithbackend.b2b.stat.controller.response;
+
+import java.util.List;
+
+public class StatResponse {
+    public record GetVendorStatResponse(
+            List<StatData> salesSize,
+            List<StatData> employeesSize
+    ) {
+        public record StatData(
+                String label,
+                Long percentage
+        ) {
+
+        }
+    }
+}

--- a/src/main/java/startwithco/startwithbackend/b2b/stat/repository/StatEntityRepositoryImpl.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/stat/repository/StatEntityRepositoryImpl.java
@@ -22,7 +22,6 @@ public class StatEntityRepositoryImpl implements StatEntityRepository {
 
     @Override
     public List<StatEntity> findAllByVendor(VendorEntity vendor) {
-
         return repository.findAllByVendor(vendor);
     }
 

--- a/src/main/java/startwithco/startwithbackend/b2b/stat/service/StatService.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/stat/service/StatService.java
@@ -1,0 +1,54 @@
+package startwithco.startwithbackend.b2b.stat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import startwithco.startwithbackend.b2b.stat.controller.response.StatResponse;
+import startwithco.startwithbackend.b2b.stat.domain.StatEntity;
+import startwithco.startwithbackend.b2b.stat.repository.StatEntityRepository;
+import startwithco.startwithbackend.b2b.stat.util.STAT_TYPE;
+import startwithco.startwithbackend.b2b.vendor.domain.VendorEntity;
+import startwithco.startwithbackend.b2b.vendor.repository.VendorEntityRepository;
+import startwithco.startwithbackend.common.service.CommonService;
+import startwithco.startwithbackend.exception.BadRequestException;
+import startwithco.startwithbackend.exception.NotFoundException;
+import startwithco.startwithbackend.exception.code.ExceptionCodeMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static startwithco.startwithbackend.b2b.stat.controller.response.StatResponse.*;
+import static startwithco.startwithbackend.b2b.stat.controller.response.StatResponse.GetVendorStatResponse.*;
+import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.*;
+import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.getCode;
+
+@Service
+@RequiredArgsConstructor
+public class StatService {
+    private final StatEntityRepository statEntityRepository;
+    private final VendorEntityRepository vendorEntityRepository;
+
+    @Transactional(readOnly = true)
+    public GetVendorStatResponse getStatEntity(Long vendorSeq) {
+        VendorEntity vendor = vendorEntityRepository.findByVendorSeq(vendorSeq)
+                .orElseThrow(() -> new NotFoundException(
+                        HttpStatus.NOT_FOUND.value(),
+                        "존재하지 않는 벤더 기업입니다.",
+                        getCode("존재하지 않는 벤더 기업입니다.", ExceptionType.NOT_FOUND)
+                ));
+        List<StatEntity> statEntities = statEntityRepository.findAllByVendor(vendor);
+
+        List<GetVendorStatResponse.StatData> salesSize = statEntities.stream()
+                .filter(stat -> stat.getStatType() == STAT_TYPE.SALES_SIZE)
+                .map(stat -> new GetVendorStatResponse.StatData(stat.getLabel(), stat.getPercentage()))
+                .toList();
+
+        List<GetVendorStatResponse.StatData> employeesSize = statEntities.stream()
+                .filter(stat -> stat.getStatType() == STAT_TYPE.EMPLOYEES_SIZE)
+                .map(stat -> new GetVendorStatResponse.StatData(stat.getLabel(), stat.getPercentage()))
+                .toList();
+
+        return new GetVendorStatResponse(salesSize, employeesSize);
+    }
+}


### PR DESCRIPTION
- Vendor의 통계 데이터를 STAT_TYPE(SALES_SIZE, EMPLOYEES_SIZE) 기준으로 구분하여 응답
- stream API를 활용해 필터링 및 매핑 로직 간결하게 처리
- 존재하지 않는 벤더에 대해서는 404 NotFoundException 예외 처리

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-