### PR TITLE
feat: 솔루션 상세 조회에 keywords 응답 추가

### DIFF
--- a/src/main/java/startwithco/startwithbackend/solution/keyword/repository/SolutionKeywordEntityJpaRepository.java
+++ b/src/main/java/startwithco/startwithbackend/solution/keyword/repository/SolutionKeywordEntityJpaRepository.java
@@ -8,10 +8,19 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import startwithco.startwithbackend.solution.keyword.domain.SolutionKeywordEntity;
 
+import java.util.List;
+
 @Repository
 public interface SolutionKeywordEntityJpaRepository extends JpaRepository<SolutionKeywordEntity, Long> {
     @Modifying
     @Transactional
     @Query("DELETE FROM SolutionKeywordEntity sk WHERE sk.solutionEntity.solutionSeq = :solutionSeq")
     void deleteAllBySolutionSeq(@Param("solutionSeq") Long solutionSeq);
+
+    @Query("""
+           SELECT ske.keyword
+           FROM SolutionKeywordEntity ske
+           WHERE ske.solutionEntity.solutionSeq = :solutionSeq
+           """)
+    List<String> findAllKeywordsBySolutionSeq(@Param("solutionSeq") Long solutionSeq);
 }

--- a/src/main/java/startwithco/startwithbackend/solution/keyword/repository/SolutionKeywordEntityRepository.java
+++ b/src/main/java/startwithco/startwithbackend/solution/keyword/repository/SolutionKeywordEntityRepository.java
@@ -8,4 +8,6 @@ public interface SolutionKeywordEntityRepository {
     List<SolutionKeywordEntity> saveAll(List<SolutionKeywordEntity> solutionKeywordEntities);
 
     void deleteAllBySolutionSeq(Long solutionSeq);
+
+    List<String> findAllKeywordsBySolutionSeq(Long solutionSeq);
 }

--- a/src/main/java/startwithco/startwithbackend/solution/keyword/repository/SolutionKeywordEntityRepositoryImpl.java
+++ b/src/main/java/startwithco/startwithbackend/solution/keyword/repository/SolutionKeywordEntityRepositoryImpl.java
@@ -19,4 +19,9 @@ public class SolutionKeywordEntityRepositoryImpl implements SolutionKeywordEntit
     public void deleteAllBySolutionSeq(Long solutionSeq) {
         repository.deleteAllBySolutionSeq(solutionSeq);
     }
+
+    @Override
+    public List<String> findAllKeywordsBySolutionSeq(Long solutionSeq) {
+        return repository.findAllKeywordsBySolutionSeq(solutionSeq);
+    }
 }

--- a/src/main/java/startwithco/startwithbackend/solution/solution/controller/response/SolutionResponse.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/controller/response/SolutionResponse.java
@@ -9,7 +9,6 @@ public class SolutionResponse {
     public record SaveSolutionEntityResponse(
             Long solutionSeq
     ) {
-
     }
 
     public record GetSolutionEntityResponse(
@@ -23,14 +22,14 @@ public class SolutionResponse {
             Long duration,
             List<String> industry,
             List<String> recommendedCompanySize,
-            List<SolutionEffectResponse> solutionEffect
+            List<SolutionEffectResponse> solutionEffect,
+            List<String> keywords
     ) {
         public record SolutionEffectResponse(
                 String effectName,
                 Long percent,
                 DIRECTION direction
         ) {
-
         }
     }
 

--- a/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
@@ -202,6 +202,7 @@ public class SolutionService {
         List<String> recommendedCompanySize = List.of(solutionEntity.getRecommendedCompanySize().split(","));
         List<SolutionEffectResponse> solutionEffectResponse
                 = solutionEffectEntityRepository.findAllBySolutionSeqCustom(solutionEntity.getSolutionSeq());
+        List<String> keywords = solutionKeywordEntityRepository.findAllKeywordsBySolutionSeq(solutionEntity.getSolutionSeq());
 
         return new GetSolutionEntityResponse(
                 solutionEntity.getSolutionSeq(),
@@ -214,7 +215,8 @@ public class SolutionService {
                 solutionEntity.getDuration(),
                 industry,
                 recommendedCompanySize,
-                solutionEffectResponse
+                solutionEffectResponse,
+                keywords
         );
     }
 
@@ -261,6 +263,7 @@ public class SolutionService {
         List<String> recommendedCompanySize = List.of(solutionEntity.getRecommendedCompanySize().split(","));
         List<SolutionEffectResponse> solutionEffectResponse
                 = solutionEffectEntityRepository.findAllBySolutionSeqCustom(solutionEntity.getSolutionSeq());
+        List<String> keywords = solutionKeywordEntityRepository.findAllKeywordsBySolutionSeq(solutionEntity.getSolutionSeq());
 
         return new GetSolutionEntityResponse(
                 solutionEntity.getSolutionSeq(),
@@ -273,7 +276,8 @@ public class SolutionService {
                 solutionEntity.getDuration(),
                 industry,
                 recommendedCompanySize,
-                solutionEffectResponse
+                solutionEffectResponse,
+                keywords
         );
     }
 


### PR DESCRIPTION
- solutionKeywordEntityRepository를 통해 solutionSeq 기반 keywords 조회 로직 추가
- GetSolutionEntityResponse 생성자에 keywords 필드 포함하여 응답 확장

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-