### PR TITLE
feat: 결제 진행 중 건 존재 시 예외 처리 로직 추가

### DIFF
--- a/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepository.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepository.java
@@ -1,6 +1,9 @@
 package startwithco.startwithbackend.payment.payment.repository;
 
+import startwithco.startwithbackend.b2b.consumer.domain.ConsumerEntity;
+import startwithco.startwithbackend.b2b.vendor.domain.VendorEntity;
 import startwithco.startwithbackend.payment.payment.domain.PaymentEntity;
+import startwithco.startwithbackend.solution.solution.domain.SolutionEntity;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,4 +28,6 @@ public interface PaymentEntityRepository {
     List<PaymentEntity> findAll(int start, int end);
 
     Optional<PaymentEntity> findByPaymentEventUniqueType(String paymentEventUniqueType);
+
+    boolean existsConflictPaymentEntity(VendorEntity vendorEntity, ConsumerEntity consumerEntity, SolutionEntity solutionEntity);
 }


### PR DESCRIPTION
- findConflictPaymentEntity 조회 결과가 존재하는 경우 ConflictException 발생하도록 구현
- 중복 결제 방지를 위해 벤더/컨슈머/솔루션 조합의 진행 중 결제 상태(IN_PROGRESS, WAITING_FOR_DEPOSIT) 확인

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-