### PR TITLE
hotfix: 결제 이벤트 존재 시 충돌 검증 로직 수정

### DIFF
--- a/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepositoryImpl.java
+++ b/src/main/java/startwithco/startwithbackend/payment/payment/repository/PaymentEntityRepositoryImpl.java
@@ -164,13 +164,15 @@ public class PaymentEntityRepositoryImpl implements PaymentEntityRepository {
 
         Integer result = queryFactory
                 .selectOne()
-                .from(p)
-                .join(p.paymentEventEntity, pe)
+                .from(pe)
+                .leftJoin(p).on(p.paymentEventEntity.eq(pe))
                 .where(
                         pe.vendorEntity.eq(vendor),
                         pe.consumerEntity.eq(consumer),
                         pe.solutionEntity.eq(solution),
-                        p.paymentStatus.in(PAYMENT_STATUS.IN_PROGRESS, PAYMENT_STATUS.WAITING_FOR_DEPOSIT)
+                        p.isNull().or(p.paymentStatus.in(
+                                PAYMENT_STATUS.IN_PROGRESS, PAYMENT_STATUS.WAITING_FOR_DEPOSIT
+                        ))
                 )
                 .fetchFirst();
 


### PR DESCRIPTION
- PaymentEntity 미존재 시에도 해당 PaymentEventEntity가 존재하면 true를 반환하도록 조건 변경
- INNER JOIN을 LEFT JOIN으로 수정하여 결제 미생성 건도 충돌로 판정 가능하게 개선
- 결제 상태가 IN_PROGRESS, WAITING_FOR_DEPOSIT이거나 결제가 없는 경우 충돌로 처리

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-