### PR TITLE
feat: 소비자 대시보드 응답에 vendorSeq 및 category 필드 추가

### DIFF
--- a/src/main/java/startwithco/startwithbackend/b2b/consumer/controller/response/ConsumerResponse.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/consumer/controller/response/ConsumerResponse.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import startwithco.startwithbackend.b2b.consumer.domain.ConsumerEntity;
 import startwithco.startwithbackend.payment.payment.util.METHOD;
 import startwithco.startwithbackend.payment.payment.util.PAYMENT_STATUS;
+import startwithco.startwithbackend.solution.solution.util.CATEGORY;
 
 import java.time.LocalDateTime;
 
@@ -42,6 +43,7 @@ public class ConsumerResponse {
 
     public record GetConsumerDashboardResponse(
             Long consumerSeq,
+            Long vendorSeq,
             PAYMENT_STATUS paymentStatus,
             LocalDateTime paymentCompletedAt,
             String representImageUrl,
@@ -51,7 +53,8 @@ public class ConsumerResponse {
             String solutionName,
             METHOD method,
             Long amount,
-            boolean existReview
+            boolean existReview,
+            CATEGORY category
     ) {
 
     }

--- a/src/main/java/startwithco/startwithbackend/b2b/consumer/service/ConsumerService.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/consumer/service/ConsumerService.java
@@ -227,6 +227,7 @@ public class ConsumerService {
 
             response.add(new GetConsumerDashboardResponse(
                     consumerEntity.getConsumerSeq(),
+                    vendorEntity.getVendorSeq(),
                     paymentEntity.getPaymentStatus(),
                     paymentEntity.getPaymentCompletedAt(),
                     solutionEntity.getRepresentImageUrl(),
@@ -236,7 +237,8 @@ public class ConsumerService {
                     solutionEntity.getSolutionName(),
                     paymentEntity.getMethod(),
                     paymentEntity.getAmount(),
-                    solutionReviewEntityRepository.existsByConsumerSeqAndSolutionSeq(consumerSeq, solutionEntity.getSolutionSeq())
+                    solutionReviewEntityRepository.existsByConsumerSeqAndSolutionSeq(consumerSeq, solutionEntity.getSolutionSeq()),
+                    solutionEntity.getCategory()
             ));
         }
 


### PR DESCRIPTION
- GetConsumerDashboardResponse 생성 시 vendorSeq와 solutionEntity.category 값 포함
- 응답 데이터에 벤더 식별자와 솔루션 카테고리 정보 제공하여 클라이언트 활용성 강화

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-