### PR TITLE
feat: 소프트 삭제 환경에서 솔루션 중복 등록 방지를 위한 비관적 락 적용

### DIFF
--- a/src/main/java/startwithco/startwithbackend/b2b/vendor/repository/VendorEntityJpaRepository.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/vendor/repository/VendorEntityJpaRepository.java
@@ -1,7 +1,12 @@
 package startwithco.startwithbackend.b2b.vendor.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
 import startwithco.startwithbackend.b2b.vendor.domain.VendorEntity;
 
@@ -28,9 +33,10 @@ public interface VendorEntityJpaRepository extends JpaRepository<VendorEntity, L
             """)
     boolean existsByVendorSeq(Long vendorSeq);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
             SELECT v FROM VendorEntity v
-            ORDER BY v.createdAt DESC
+            WHERE v.vendorSeq = :vendorSeq
             """)
-    List<VendorEntity> findAllByCreatedAtDesc();
+    Optional<VendorEntity> findByVendorSeqForUpdate(@Param("vendorSeq") Long vendorSeq);
 }

--- a/src/main/java/startwithco/startwithbackend/b2b/vendor/repository/VendorEntityRepository.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/vendor/repository/VendorEntityRepository.java
@@ -19,4 +19,6 @@ public interface VendorEntityRepository {
     void saveBlackToken(String token);
 
     List<VendorEntity> getAllVendorEntity(int start, int end);
+
+    Optional<VendorEntity> findByVendorSeqForUpdate(Long vendorSeq);
 }

--- a/src/main/java/startwithco/startwithbackend/b2b/vendor/repository/VendorEntityRepositoryImpl.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/vendor/repository/VendorEntityRepositoryImpl.java
@@ -68,4 +68,9 @@ public class VendorEntityRepositoryImpl implements VendorEntityRepository {
                 .limit(end - start)
                 .fetch();
     }
+
+    @Override
+    public Optional<VendorEntity> findByVendorSeqForUpdate(Long vendorSeq) {
+        return repository.findByVendorSeqForUpdate(vendorSeq);
+    }
 }

--- a/src/main/java/startwithco/startwithbackend/solution/solution/domain/SolutionEntity.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/domain/SolutionEntity.java
@@ -5,18 +5,16 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import startwithco.startwithbackend.b2b.vendor.domain.VendorEntity;
 import startwithco.startwithbackend.base.BaseTimeEntity;
 import startwithco.startwithbackend.solution.solution.util.CATEGORY;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(
-        name = "SOLUTION_ENTITY",
-        uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"vendor_seq", "category"})
-        }
-)
+@SQLDelete(sql = "UPDATE SOLUTION_ENTITY SET deleted = true WHERE solution_seq = ?")
+@Where(clause = "deleted = false")
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter

--- a/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
@@ -1,5 +1,6 @@
 package startwithco.startwithbackend.solution.solution.service;
 
+import jakarta.persistence.LockTimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -47,12 +48,13 @@ public class SolutionService {
 
     @Transactional
     public SaveSolutionEntityResponse saveSolutionEntity(SaveSolutionEntityRequest request, MultipartFile representImageUrl, MultipartFile descriptionPdfUrl) {
-        VendorEntity vendorEntity = vendorEntityRepository.findByVendorSeq(request.vendorSeq())
+        VendorEntity vendorEntity = vendorEntityRepository.findByVendorSeqForUpdate(request.vendorSeq())
                 .orElseThrow(() -> new NotFoundException(
                         HttpStatus.NOT_FOUND.value(),
                         "존재하지 않는 벤더 기업입니다.",
                         getCode("존재하지 않는 벤더 기업입니다.", ExceptionType.NOT_FOUND)
                 ));
+
         solutionEntityRepository.findByVendorSeqAndCategory(request.vendorSeq(), CATEGORY.valueOf(request.category()))
                 .ifPresent(solutionEntity -> {
                     throw new ConflictException(
@@ -117,7 +119,7 @@ public class SolutionService {
 
     @Transactional
     public void modifySolutionEntity(SaveSolutionEntityRequest request, MultipartFile representImageUrl, MultipartFile descriptionPdfUrl) {
-        vendorEntityRepository.findByVendorSeq(request.vendorSeq())
+        vendorEntityRepository.findByVendorSeqForUpdate(request.vendorSeq())
                 .orElseThrow(() -> new NotFoundException(
                         HttpStatus.NOT_FOUND.value(),
                         "존재하지 않는 벤더 기업입니다.",


### PR DESCRIPTION
- vendor_seq, category 조합의 복합 유니크 키 대신 VendorEntity에 PESSIMISTIC_WRITE 락 적용
- 동일 벤더에 대한 동시 요청 시 직렬화 처리하여 중복 insert 방지
- @Where(clause = "deleted = false")를 활용해 deleted=true 상태에서는 재등록 가능
- @QueryHint로 lock timeout(3초) 설정하여 무한 대기 방지
- 저장 및 수정 로직 모두 벤더 락 → 활성 존재 확인 → 저장 순서로 변경

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-