### PR TITLE
hotfix: 카테고리 변경 시 타 카테고리 행 덮어쓰기 버그 수정

### DIFF
--- a/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
+++ b/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
@@ -43,6 +43,7 @@ public class ExceptionCodeMapper {
         NOT_FOUND_MAP.put("수신자가 수요/벤더 기업에 존재하지 않습니다.", "NOT_FOUND_EXCEPTION_011");
         NOT_FOUND_MAP.put("존재하지 않는 사용자입니다.", "NOT_FOUND_EXCEPTION_012");
         NOT_FOUND_MAP.put("존재하지 않는 채팅 Unique Type 입니다.", "NOT_FOUND_EXCEPTION_013");
+        NOT_FOUND_MAP.put("이미 존재하는 카테고리입니다.", "NOT_FOUND_EXCEPTION_014");
 
         // ServerException
         SERVER_MAP.put("내부 서버 오류가 발생했습니다.", "SERVER_EXCEPTION_001");

--- a/src/main/java/startwithco/startwithbackend/solution/solution/controller/SolutionController.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/controller/SolutionController.java
@@ -17,12 +17,14 @@ import startwithco.startwithbackend.base.BaseResponse;
 import startwithco.startwithbackend.exception.BadRequestException;
 import startwithco.startwithbackend.exception.code.ExceptionCodeMapper;
 import startwithco.startwithbackend.exception.handler.GlobalExceptionHandler;
+import startwithco.startwithbackend.solution.solution.controller.request.SolutionRequest;
 import startwithco.startwithbackend.solution.solution.service.SolutionService;
 import startwithco.startwithbackend.solution.solution.util.CATEGORY;
 
 import java.util.List;
 
 import static startwithco.startwithbackend.exception.code.ExceptionCodeMapper.getCode;
+import static startwithco.startwithbackend.solution.solution.controller.request.SolutionRequest.*;
 import static startwithco.startwithbackend.solution.solution.controller.request.SolutionRequest.SaveSolutionEntityRequest;
 import static startwithco.startwithbackend.solution.solution.controller.response.SolutionResponse.*;
 import static startwithco.startwithbackend.solution.solution.controller.response.SolutionResponse.SaveSolutionEntityResponse;
@@ -97,7 +99,7 @@ public class SolutionController {
             @Valid
             @RequestPart(value = "representImageUrl", required = false) MultipartFile representImageUrl,
             @RequestPart(value = "descriptionPdfUrl", required = false) MultipartFile descriptionPdfUrl,
-            @RequestPart SaveSolutionEntityRequest request
+            @RequestPart ModifySolutionEntityRequest request
     ) {
         request.validate();
         if (representImageUrl.isEmpty() || descriptionPdfUrl.isEmpty()) {

--- a/src/main/java/startwithco/startwithbackend/solution/solution/controller/request/SolutionRequest.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/controller/request/SolutionRequest.java
@@ -84,4 +84,79 @@ public class SolutionRequest {
             }
         }
     }
+
+    public record ModifySolutionEntityRequest(
+            // 솔루션 기본 정보 입력
+            Long vendorSeq,
+            String solutionName,
+            String solutionDetail,
+            String prevCategory,
+            String nextCategory,
+            String industry,
+            String recommendedCompanySize,
+            String solutionImplementationType,
+
+            // 판매 정보 입력
+            Long amount,
+            Long duration,
+
+            // 솔루션 상세 정보 입력
+            List<SolutionEffectEntityRequest> solutionEffect,
+
+            // 키워드 검색 태그
+            List<String> keyword
+    ) {
+        public record SolutionEffectEntityRequest(
+                String effectName,
+                Long percent,
+                String direction
+        ) {
+
+        }
+
+        public void validate() {
+            if (vendorSeq == null ||
+                    isBlank(solutionName) ||
+                    isBlank(solutionDetail) ||
+                    prevCategory == null ||
+                    nextCategory == null ||
+                    isBlank(industry) ||
+                    isBlank(recommendedCompanySize) ||
+                    isBlank(solutionImplementationType) ||
+                    amount == null ||
+                    duration == null ||
+                    CollectionUtils.isEmpty(keyword)) {
+                throw new BadRequestException(
+                        HttpStatus.BAD_REQUEST.value(),
+                        "요청 데이터 오류입니다.",
+                        getCode("요청 데이터 오류입니다.", ExceptionCodeMapper.ExceptionType.BAD_REQUEST)
+                );
+            }
+
+            try {
+                CATEGORY.valueOf(prevCategory.toUpperCase());
+                CATEGORY.valueOf(nextCategory.toUpperCase());
+
+                if (!CollectionUtils.isEmpty(solutionEffect)) {
+                    for (SolutionEffectEntityRequest effect : solutionEffect) {
+                        DIRECTION.valueOf(effect.direction().toUpperCase());
+                    }
+                }
+            } catch (Exception e) {
+                throw new BadRequestException(
+                        HttpStatus.BAD_REQUEST.value(),
+                        "요청 데이터 오류입니다.",
+                        getCode("요청 데이터 오류입니다.", ExceptionCodeMapper.ExceptionType.BAD_REQUEST)
+                );
+            }
+
+            if (amount < 0) {
+                throw new BadRequestException(
+                        HttpStatus.BAD_REQUEST.value(),
+                        "요청 데이터 오류입니다.",
+                        getCode("요청 데이터 오류입니다.", ExceptionCodeMapper.ExceptionType.BAD_REQUEST)
+                );
+            }
+        }
+    }
 }

--- a/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
@@ -118,14 +118,20 @@ public class SolutionService {
     }
 
     @Transactional
-    public void modifySolutionEntity(SaveSolutionEntityRequest request, MultipartFile representImageUrl, MultipartFile descriptionPdfUrl) {
+    public void modifySolutionEntity(ModifySolutionEntityRequest request, MultipartFile representImageUrl, MultipartFile descriptionPdfUrl) {
         vendorEntityRepository.findByVendorSeqForUpdate(request.vendorSeq())
                 .orElseThrow(() -> new NotFoundException(
                         HttpStatus.NOT_FOUND.value(),
                         "존재하지 않는 벤더 기업입니다.",
                         getCode("존재하지 않는 벤더 기업입니다.", ExceptionType.NOT_FOUND)
                 ));
-        SolutionEntity solutionEntity = solutionEntityRepository.findByVendorSeqAndCategory(request.vendorSeq(), CATEGORY.valueOf(request.category()))
+        solutionEntityRepository.findByVendorSeqAndCategory(request.vendorSeq(), CATEGORY.valueOf(request.nextCategory()))
+                .orElseThrow(() -> new NotFoundException(
+                        HttpStatus.NOT_FOUND.value(),
+                        "이미 존재하는 카테고리입니다.",
+                        getCode("이미 존재하는 카테고리입니다.", ExceptionType.NOT_FOUND)
+                ));
+        SolutionEntity solutionEntity = solutionEntityRepository.findByVendorSeqAndCategory(request.vendorSeq(), CATEGORY.valueOf(request.prevCategory()))
                 .orElseThrow(() -> new NotFoundException(
                         HttpStatus.NOT_FOUND.value(),
                         "존재하지 않는 솔루션입니다.",
@@ -139,7 +145,7 @@ public class SolutionService {
             SolutionEntity updatedSolutionEntity = solutionEntity.updateSolutionEntity(
                     request.solutionName(),
                     request.solutionDetail(),
-                    CATEGORY.valueOf(request.category()),
+                    CATEGORY.valueOf(request.nextCategory()),
                     request.industry(),
                     request.recommendedCompanySize(),
                     request.solutionImplementationType(),


### PR DESCRIPTION
- 수정 대상 엔티티를 (vendorSeq, category) 조회에서 solutionSeq 기반 조회로 변경
- 동일 벤더에 대한 동시 수정 직렬화를 위해 VendorEntity PESSIMISTIC_WRITE 락 유지
- 카테고리 변경 요청 시 동일 벤더 내 해당 카테고리 활성 레코드 사전 검증 및 409 Conflict 반환
- 부가 엔티티(effect, keyword) 갱신 로직은 기존 흐름 유지
- DataIntegrityViolationException 처리 로직 유지 및 예외 메시지 정비

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-