### PR TITLE
hotfix: 솔루션 수정 시 카테고리 변경 로직 및 중복 검증 버그 수정

### DIFF
--- a/src/main/java/startwithco/startwithbackend/b2b/vendor/service/VendorService.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/vendor/service/VendorService.java
@@ -70,6 +70,8 @@ public class VendorService {
     private long accessTokenExpiration;
     @Value("${jwt.refreshTokenExpiration}")
     private long refreshTokenExpiration;
+    @Value("${app.frontend.reset-link}")
+    private String resetLink;
 
     @Transactional(readOnly = true)
     public List<GetVendorSolutionCategoryResponse> getVendorSolutionCategory(Long vendorSeq) {
@@ -386,8 +388,6 @@ public class VendorService {
 
         // 토큰 생성
         String token = generateToken(1_800_000L, vendorEntity.getVendorSeq());
-
-        String resetLink = "http://localhost:3000/forget/reset?token=" + token;
 
         commonService.sendResetLink(vendorEntity.getEmail(), resetLink);
 

--- a/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
+++ b/src/main/java/startwithco/startwithbackend/exception/code/ExceptionCodeMapper.java
@@ -28,6 +28,7 @@ public class ExceptionCodeMapper {
         CONFLICT_MAP.put("해당 벤더의 해당 카테고리 솔루션이 이미 존재합니다.", "CONFLICT_EXCEPTION_004");
         CONFLICT_MAP.put("같은 솔루션에 리뷰는 한 번만 작성할 수 있습니다.", "CONFLICT_EXCEPTION_005");
         CONFLICT_MAP.put("이미 해당 결제 요청에 대한 결제 정보가 존재합니다. 새롭게 결제 요청을 진행해야합니다.", "CONFLICT_EXCEPTION_006");
+        NOT_FOUND_MAP.put("이미 존재하는 카테고리입니다.", "CONFLICT_EXCEPTION_007");
 
         // NotFoundException
         NOT_FOUND_MAP.put("존재하지 않는 벤더 기업입니다.", "NOT_FOUND_EXCEPTION_001");
@@ -43,7 +44,6 @@ public class ExceptionCodeMapper {
         NOT_FOUND_MAP.put("수신자가 수요/벤더 기업에 존재하지 않습니다.", "NOT_FOUND_EXCEPTION_011");
         NOT_FOUND_MAP.put("존재하지 않는 사용자입니다.", "NOT_FOUND_EXCEPTION_012");
         NOT_FOUND_MAP.put("존재하지 않는 채팅 Unique Type 입니다.", "NOT_FOUND_EXCEPTION_013");
-        NOT_FOUND_MAP.put("이미 존재하는 카테고리입니다.", "NOT_FOUND_EXCEPTION_014");
 
         // ServerException
         SERVER_MAP.put("내부 서버 오류가 발생했습니다.", "SERVER_EXCEPTION_001");

--- a/src/main/java/startwithco/startwithbackend/solution/solution/controller/SolutionController.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/controller/SolutionController.java
@@ -92,6 +92,7 @@ public class SolutionController {
             @ApiResponse(responseCode = "SERVER_EXCEPTION_001", description = "내부 서버 오류가 발생했습니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "BAD_REQUEST_EXCEPTION_001", description = "요청 데이터 오류입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "NOT_FOUND_EXCEPTION_005", description = "존재하지 않는 솔루션입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+            @ApiResponse(responseCode = "CONFLICT_EXCEPTION_007", description = "이미 존재하는 카테고리입니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "CONFLICT_EXCEPTION_002", description = "동시성 저장은 불가능합니다.", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
             @ApiResponse(responseCode = "SERVER_EXCEPTION_002", description = "S3 UPLOAD 실패", content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
     })

--- a/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
+++ b/src/main/java/startwithco/startwithbackend/solution/solution/service/SolutionService.java
@@ -125,18 +125,25 @@ public class SolutionService {
                         "존재하지 않는 벤더 기업입니다.",
                         getCode("존재하지 않는 벤더 기업입니다.", ExceptionType.NOT_FOUND)
                 ));
-        solutionEntityRepository.findByVendorSeqAndCategory(request.vendorSeq(), CATEGORY.valueOf(request.nextCategory()))
-                .orElseThrow(() -> new NotFoundException(
-                        HttpStatus.NOT_FOUND.value(),
-                        "이미 존재하는 카테고리입니다.",
-                        getCode("이미 존재하는 카테고리입니다.", ExceptionType.NOT_FOUND)
-                ));
-        SolutionEntity solutionEntity = solutionEntityRepository.findByVendorSeqAndCategory(request.vendorSeq(), CATEGORY.valueOf(request.prevCategory()))
+
+        CATEGORY prevCat = CATEGORY.valueOf(request.prevCategory());
+        CATEGORY nextCat = CATEGORY.valueOf(request.nextCategory());
+
+        SolutionEntity solutionEntity = solutionEntityRepository.findByVendorSeqAndCategory(request.vendorSeq(), prevCat)
                 .orElseThrow(() -> new NotFoundException(
                         HttpStatus.NOT_FOUND.value(),
                         "존재하지 않는 솔루션입니다.",
                         getCode("존재하지 않는 솔루션입니다.", ExceptionType.NOT_FOUND)
                 ));
+
+        if (!prevCat.equals(nextCat)) {
+            solutionEntityRepository.findByVendorSeqAndCategory(request.vendorSeq(), nextCat)
+                    .ifPresent(x -> { throw new ConflictException(
+                            HttpStatus.CONFLICT.value(),
+                            "이미 존재하는 카테고리입니다.",
+                            getCode("이미 존재하는 카테고리입니다.", ExceptionType.CONFLICT)
+                    );});
+        }
 
         try {
             String s3RepresentImageUrl = commonService.uploadJPGFile(representImageUrl);


### PR DESCRIPTION
- 수정 대상 엔티티를 prevCategory 기준으로 조회하도록 변경하여 타 카테고리 행 덮어쓰기 방지
- prevCategory ≠ nextCategory 인 경우, nextCategory 활성 존재 여부 사전 검증 후 존재 시 409 Conflict 반환
- 동일 벤더 작업 직렬화를 위한 VendorEntity PESSIMISTIC_WRITE 락 유지
- 예외 코드/메시지 정비: “이미 존재하는 카테고리” 상황을 404 → 409로 수정
- 부가 엔티티(effect, keyword) 재적재 로직은 기존 흐름 유지

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-