### PR TITLE
fix: vendor 프로필 이미지 업로드 로직에서 잘못된 null 체크 수정

### DIFF
--- a/src/main/java/startwithco/startwithbackend/b2b/vendor/controller/VendorController.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/vendor/controller/VendorController.java
@@ -216,7 +216,7 @@ public class VendorController {
 
         vendorService.updateVendor(request, vendorBannerImageUrl, clientInfos, vendorProfileImage);
 
-        return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), "success"));
+        return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), "SUCCESS"));
     }
 
     @PostMapping(value = "/resetLink", name = "Vendor 비번 리셋 링크")

--- a/src/main/java/startwithco/startwithbackend/b2b/vendor/service/VendorService.java
+++ b/src/main/java/startwithco/startwithbackend/b2b/vendor/service/VendorService.java
@@ -241,8 +241,8 @@ public class VendorService {
                         getCode("존재하지 않는 벤더 기업입니다.", ExceptionType.NOT_FOUND)
                 ));
 
-        String vendorBannerImage = vendorBannerImageUrl == null ? null : commonService.uploadJPGFile(vendorBannerImageUrl);
-        String vendorProfileImage = vendorBannerImageUrl == null ? null : commonService.uploadJPGFile(profileImage);
+        String vendorBannerImage = (vendorBannerImageUrl != null && !vendorBannerImageUrl.isEmpty()) ? commonService.uploadJPGFile(vendorBannerImageUrl) : null;
+        String vendorProfileImage = (profileImage != null && !profileImage.isEmpty()) ? commonService.uploadJPGFile(profileImage) : null;
 
         vendorEntity.update(
                 request.vendorName(),


### PR DESCRIPTION
- vendorProfileImage 할당 시 vendorBannerImageUrl이 아닌 profileImage 기준으로 null 체크하도록 수정
- 프로필 이미지 업로드 시 NPE 발생 가능성 제거

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-